### PR TITLE
Don't use array notation for relations that can't have multiple entries

### DIFF
--- a/core/src/main/java/io/wcm/caravan/rhyme/api/spi/HalApiReturnTypeSupport.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/api/spi/HalApiReturnTypeSupport.java
@@ -41,4 +41,10 @@ public interface HalApiReturnTypeSupport {
    */
   Function<? super Object, Observable<?>> convertToObservable(Class<?> sourceType);
 
+  /**
+   * @param returnType the return type of an annotated method
+   * @return true if the type is a collection or a reactive type that can emit multiple values
+   */
+  boolean isProviderOfMultiplerValues(Class<?> returnType);
+
 }

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/reflection/CompositeHalApiTypeSupport.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/reflection/CompositeHalApiTypeSupport.java
@@ -108,7 +108,14 @@ public class CompositeHalApiTypeSupport implements HalApiTypeSupport {
     return firstNonNull(delegate -> delegate.convertToObservable(sourceType));
   }
 
+  @Override
+  public boolean isProviderOfMultiplerValues(Class<?> returnType) {
+
+    return anyMatch(delegate -> delegate.isProviderOfMultiplerValues(returnType));
+  }
+
   List<HalApiTypeSupport> getDelegates() {
     return delegates;
   }
+
 }

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/reflection/DefaultHalApiTypeSupport.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/reflection/DefaultHalApiTypeSupport.java
@@ -162,6 +162,15 @@ public class DefaultHalApiTypeSupport implements HalApiTypeSupport {
     return null;
   }
 
+  @Override
+  public boolean isProviderOfMultiplerValues(Class<?> returnType) {
+
+    return List.class.isAssignableFrom(returnType)
+        || Stream.class.isAssignableFrom(returnType)
+        || Observable.class.isAssignableFrom(returnType)
+        || Publisher.class.isAssignableFrom(returnType);
+  }
+
   /**
    * @param annotationSupport additional support for different annotations
    * @param returnTypeSupport additional support for different return types
@@ -175,4 +184,5 @@ public class DefaultHalApiTypeSupport implements HalApiTypeSupport {
 
     return new CompositeHalApiTypeSupport(ImmutableList.of(defaultSupport, adapter));
   }
+
 }

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/reflection/HalApiTypeSupportAdapter.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/reflection/HalApiTypeSupportAdapter.java
@@ -108,6 +108,11 @@ public class HalApiTypeSupportAdapter implements HalApiTypeSupport {
     return returnTypeSupport.convertToObservable(sourceType);
   }
 
+  @Override
+  public boolean isProviderOfMultiplerValues(Class<?> returnType) {
+    return returnTypeSupport.isProviderOfMultiplerValues(returnType);
+  }
+
   HalApiAnnotationSupport getAnnotationSupport() {
     return annotationSupport;
   }
@@ -126,6 +131,11 @@ public class HalApiTypeSupportAdapter implements HalApiTypeSupport {
     @Override
     public Function<? super Object, Observable<?>> convertToObservable(Class<?> sourceType) {
       return null;
+    }
+
+    @Override
+    public boolean isProviderOfMultiplerValues(Class<?> returnType) {
+      return false;
     }
 
   }

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/renderer/AsyncHalResourceRendererImpl.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/renderer/AsyncHalResourceRendererImpl.java
@@ -143,8 +143,20 @@ public final class AsyncHalResourceRendererImpl implements AsyncHalResourceRende
     }
 
     for (RelationRenderResult related : listOfRelated) {
-      hal.addLinks(related.getRelation(), related.getLinks());
-      hal.addEmbedded(related.getRelation(), related.getEmbedded());
+      String relation = related.getRelation();
+
+      if (related.isMultiValue()) {
+        hal.addLinks(relation, related.getLinks());
+        hal.addEmbedded(relation, related.getEmbedded());
+      }
+      else {
+        if (!related.getLinks().isEmpty()) {
+          hal.setLink(relation, related.getLinks().get(0));
+        }
+        if (!related.getEmbedded().isEmpty()) {
+          hal.setEmbedded(relation, related.getEmbedded().get(0));
+        }
+      }
     }
 
     return hal;

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/renderer/RelatedResourcesRendererImpl.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/renderer/RelatedResourcesRendererImpl.java
@@ -81,6 +81,7 @@ final class RelatedResourcesRendererImpl {
 
     verifyReturnType(resourceImplInstance, method);
     String relation = typeSupport.getRelation(method);
+    boolean multiValue = typeSupport.isProviderOfMultiplerValues(method.getReturnType());
 
     // call the implementation of the method to get an observable of related resource implementation instances
     Observable<?> rxRelatedResources = invokeMethodAndReturnObservable(resourceImplInstance, method, metrics, typeSupport)
@@ -105,7 +106,7 @@ final class RelatedResourcesRendererImpl {
                 + " This is not the case for " + unsupportedClassNames);
           }
 
-          return new RelationRenderResult(relation, links, embeddedResources);
+          return new RelationRenderResult(relation, links, embeddedResources, multiValue);
         });
 
     Class<?> emissionType = RxJavaReflectionUtils.getObservableEmissionType(method, typeSupport);
@@ -227,10 +228,14 @@ final class RelatedResourcesRendererImpl {
     private final List<Link> links;
     private final List<HalResource> embedded;
 
-    private RelationRenderResult(String relation, List<Link> links, List<HalResource> embedded) {
+    private final boolean multiValue;
+
+
+    private RelationRenderResult(String relation, List<Link> links, List<HalResource> embedded, boolean multiValue) {
       this.relation = relation;
       this.links = links;
       this.embedded = embedded;
+      this.multiValue = multiValue;
     }
 
     String getRelation() {
@@ -244,5 +249,10 @@ final class RelatedResourcesRendererImpl {
     List<HalResource> getEmbedded() {
       return this.embedded;
     }
+
+    boolean isMultiValue() {
+      return multiValue;
+    }
+
   }
 }

--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/RhymeBuilderImplTest.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/RhymeBuilderImplTest.java
@@ -238,6 +238,11 @@ public class RhymeBuilderImplTest {
       return null;
     }
 
+    @Override
+    public boolean isProviderOfMultiplerValues(Class<?> returnType) {
+      return false;
+    }
+
   }
 
   @MyApiInterface

--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/client/ErrorHandlingTest.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/client/ErrorHandlingTest.java
@@ -207,6 +207,11 @@ public class ErrorHandlingTest {
           throw cause;
         };
       }
+
+      @Override
+      public boolean isProviderOfMultiplerValues(Class<?> returnType) {
+        return false;
+      }
     };
 
     client.mockHalResponseWithState(ENTRY_POINT_URI, new TestState());

--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/reflection/CompositeHalApiTypeSupportTest.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/reflection/CompositeHalApiTypeSupportTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.when;
 import java.lang.reflect.Method;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
@@ -145,6 +146,15 @@ public class CompositeHalApiTypeSupportTest {
     fut.apply(verify(mockAnnotationSupport));
   }
 
+  private void assertThatCompositeReturnsFirstTrueValueOfReturnTypeMock(Function<HalApiReturnTypeSupport, Boolean> fut) {
+
+    HalApiTypeSupport composite = createCompositeTypeSupport();
+
+    when(fut.apply(mockReturnTypeSupport)).thenReturn(true);
+    assertThat(fut.apply(composite)).isTrue();
+    fut.apply(verify(mockReturnTypeSupport));
+  }
+
   private void assertThatCompositeReturnsFirstNonNullValueOfMock(Function<HalApiAnnotationSupport, Object> fut, Object returnValue) {
 
     HalApiTypeSupport composite = createCompositeTypeSupport();
@@ -229,4 +239,11 @@ public class CompositeHalApiTypeSupportTest {
     Function<Object, Observable<?>> fun = o -> Observable.fromIterable(() -> ((List)o).iterator());
     assertThatCompositeReturnsFirstNonNullValueOfReturnTypeMock(a -> a.convertToObservable(Iterator.class), fun);
   }
+
+  @Test
+  public void isProviderOfMultiplerValues_should_return_first_true_value() throws Exception {
+
+    assertThatCompositeReturnsFirstTrueValueOfReturnTypeMock(a -> a.isProviderOfMultiplerValues(Set.class));
+  }
+
 }

--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/renderer/RenderEmbeddedResourceTest.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/renderer/RenderEmbeddedResourceTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.Single;
 import io.wcm.caravan.hal.resource.HalResource;
 import io.wcm.caravan.hal.resource.Link;
 import io.wcm.caravan.rhyme.api.annotations.HalApiInterface;
@@ -183,5 +184,34 @@ public class RenderEmbeddedResourceTest {
     HalResource hal = render(resourceImpl);
     assertThat(hal.getEmbedded(ITEM)).hasSameSizeAs(states);
     assertThat(hal.getLinks(ITEM)).isEmpty();
+  }
+
+  @HalApiInterface
+  public interface TestResourceWithSingleEmbedded {
+
+    @Related(ITEM)
+    Single<TestResource> getEmbeddedItem();
+  }
+
+  @Test
+  public void single_embedded_resources_should_be_rendered_in_object() {
+
+    TestState state = new TestState(0);
+
+    TestResourceWithSingleEmbedded resourceImpl = new TestResourceWithSingleEmbedded() {
+
+      @Override
+      public Single<TestResource> getEmbeddedItem() {
+
+        return Single.just(new EmbeddedTestResource(state));
+      }
+    };
+
+    HalResource hal = render(resourceImpl);
+
+    List<HalResource> actualEmbedded = hal.getEmbedded(ITEM);
+
+    assertThat(actualEmbedded).hasSize(1);
+    assertThat(hal.getModel().path("_embedded").path(ITEM).isObject()).isEqualTo(true);
   }
 }

--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/renderer/RenderLinkedResourceTest.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/renderer/RenderLinkedResourceTest.java
@@ -96,6 +96,7 @@ public class RenderLinkedResourceTest {
 
     assertThat(hal.getEmbedded(LINKED)).isEmpty();
     assertThat(hal.getLinks(LINKED)).containsExactly(testLink);
+    assertThat(hal.getModel().path("_links").path(LINKED).isObject()).isTrue();
   }
 
   @HalApiInterface
@@ -130,6 +131,7 @@ public class RenderLinkedResourceTest {
 
     assertThat(hal.getEmbedded(LINKED)).isEmpty();
     assertThat(hal.getLinks(LINKED)).containsExactly(testLink);
+    assertThat(hal.getModel().path("_links").path(LINKED).isObject()).isTrue();
   }
 
   @Test
@@ -147,6 +149,7 @@ public class RenderLinkedResourceTest {
     HalResource hal = render(resourceImpl);
     assertThat(hal.getEmbedded(LINKED)).isEmpty();
     assertThat(hal.getLinks(LINKED)).isEmpty();
+    assertThat(hal.getModel().path("_links").path(LINKED).isMissingNode()).isTrue();
   }
 
   @HalApiInterface
@@ -257,6 +260,7 @@ public class RenderLinkedResourceTest {
 
     assertThat(hal.getEmbedded(LINKED)).isEmpty();
     assertThat(hal.getLinks(LINKED)).containsExactly(testLink);
+    assertThat(hal.getModel().path("_links").path(LINKED).isObject()).isTrue();
   }
 
   @HalApiInterface
@@ -282,6 +286,7 @@ public class RenderLinkedResourceTest {
     HalResource hal = render(resourceImpl);
 
     assertThat(hal.getLinks(LINKED)).containsExactly(externalLink);
+    assertThat(hal.getModel().path("_links").path(LINKED).isObject()).isTrue();
   }
 
   @Test

--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/renderer/blocking/RenderEmbeddedResourceTest.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/renderer/blocking/RenderEmbeddedResourceTest.java
@@ -189,4 +189,33 @@ public class RenderEmbeddedResourceTest {
     assertThat(hal.getLinks(ITEM)).hasSameSizeAs(states);
   }
 
+  @HalApiInterface
+  public interface TestResourceWithSingleEmbedded {
+
+    @Related(ITEM)
+    BlockingTestResource getEmbeddedItem();
+  }
+
+  @Test
+  public void single_embedded_resources_should_be_rendered_in_object() {
+
+    TestState state = new TestState(0);
+
+    TestResourceWithSingleEmbedded resourceImpl = new TestResourceWithSingleEmbedded() {
+
+      @Override
+      public BlockingTestResource getEmbeddedItem() {
+
+        return new EmbeddedTestResource(state);
+      }
+    };
+
+    HalResource hal = render(resourceImpl);
+
+    List<HalResource> actualEmbedded = hal.getEmbedded(ITEM);
+
+    assertThat(actualEmbedded).hasSize(1);
+    assertThat(hal.getModel().path("_embedded").path(ITEM).isObject()).isEqualTo(true);
+  }
+
 }

--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/renderer/blocking/RenderLinkedResourceTest.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/renderer/blocking/RenderLinkedResourceTest.java
@@ -78,6 +78,7 @@ public class RenderLinkedResourceTest {
 
     assertThat(hal.getEmbedded(LINKED)).isEmpty();
     assertThat(hal.getLinks(LINKED)).containsExactly(testLink);
+    assertThat(hal.getModel().path("_links").path(LINKED).isObject()).isTrue();
   }
 
   @HalApiInterface
@@ -112,6 +113,7 @@ public class RenderLinkedResourceTest {
 
     assertThat(hal.getEmbedded(LINKED)).isEmpty();
     assertThat(hal.getLinks(LINKED)).containsExactly(testLink);
+    assertThat(hal.getModel().path("_links").path(LINKED).isObject()).isTrue();
   }
 
   @Test
@@ -129,6 +131,7 @@ public class RenderLinkedResourceTest {
     HalResource hal = render(resourceImpl);
     assertThat(hal.getEmbedded(LINKED)).isEmpty();
     assertThat(hal.getLinks(LINKED)).isEmpty();
+    assertThat(hal.getModel().path("_links").path(LINKED).isMissingNode()).isTrue();
   }
 
 
@@ -203,6 +206,7 @@ public class RenderLinkedResourceTest {
     HalResource hal = render(resourceImpl);
 
     assertThat(hal.getLinks(LINKED)).containsExactly(externalLink);
+    assertThat(hal.getModel().path("_links").path(LINKED).isObject()).isTrue();
   }
 
   @Test


### PR DESCRIPTION
when generating HAL resources, in the _links and _embedded sections we shouldn't use arrays for relations that (according to the return type of the API interfaces) cannot contain multiple entries.

Instead, the output should use the simpler object notation e.g. 
```
 "_links": {
        "next": { "href": "/orders?page=2" }
}
```