### PR TITLE
Remove Lombok dependency in spring-hypermedia example

### DIFF
--- a/examples/spring-hypermedia/pom.xml
+++ b/examples/spring-hypermedia/pom.xml
@@ -73,11 +73,6 @@
       <artifactId>h2</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>org.projectlombok</groupId>
-      <artifactId>lombok</artifactId>
-    </dependency>
-
     <!-- wcm.io Caravan dependencies -->
     <dependency>
       <groupId>io.wcm.caravan</groupId>

--- a/examples/spring-hypermedia/src/main/java/io/wcm/caravan/rhyme/examples/spring/hypermedia/Employee.java
+++ b/examples/spring-hypermedia/src/main/java/io/wcm/caravan/rhyme/examples/spring/hypermedia/Employee.java
@@ -23,24 +23,18 @@ import javax.persistence.OneToOne;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
-import lombok.Data;
-import lombok.Generated;
-import lombok.NoArgsConstructor;
-
 /**
  * @author Greg Turnquist
  */
-@Data
 @Entity
 @EntityListeners(RepositoryModificationListener.class)
-@Generated
-@NoArgsConstructor
 public class Employee {
 
   /** a generated ID (to be used in all the link templates) */
   @Id
   @GeneratedValue
   private Long id;
+
 
   /** the first name */
   private String name;
@@ -59,6 +53,49 @@ public class Employee {
 
     this.name = name;
     this.role = role;
+    this.manager = manager;
+  }
+
+  public Employee() {
+    // required for
+  }
+
+  public Long getId() {
+    return this.id;
+  }
+
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+
+  public String getName() {
+    return this.name;
+  }
+
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+
+  public String getRole() {
+    return this.role;
+  }
+
+
+  public void setRole(String role) {
+    this.role = role;
+  }
+
+
+  public Manager getManager() {
+    return this.manager;
+  }
+
+
+  public void setManager(Manager manager) {
     this.manager = manager;
   }
 

--- a/examples/spring-hypermedia/src/main/java/io/wcm/caravan/rhyme/examples/spring/hypermedia/Employee.java
+++ b/examples/spring-hypermedia/src/main/java/io/wcm/caravan/rhyme/examples/spring/hypermedia/Employee.java
@@ -89,14 +89,4 @@ public class Employee {
     this.role = role;
   }
 
-
-  public Manager getManager() {
-    return this.manager;
-  }
-
-
-  public void setManager(Manager manager) {
-    this.manager = manager;
-  }
-
 }

--- a/examples/spring-hypermedia/src/main/java/io/wcm/caravan/rhyme/examples/spring/hypermedia/Employee.java
+++ b/examples/spring-hypermedia/src/main/java/io/wcm/caravan/rhyme/examples/spring/hypermedia/Employee.java
@@ -57,36 +57,30 @@ public class Employee {
   }
 
   public Employee() {
-    // required for
+    // required for deserialization
   }
 
   public Long getId() {
     return this.id;
   }
 
-
   public void setId(Long id) {
     this.id = id;
   }
-
 
   public String getName() {
     return this.name;
   }
 
-
   public void setName(String name) {
     this.name = name;
   }
-
 
   public String getRole() {
     return this.role;
   }
 
-
   public void setRole(String role) {
     this.role = role;
   }
-
 }

--- a/examples/spring-hypermedia/src/main/java/io/wcm/caravan/rhyme/examples/spring/hypermedia/Manager.java
+++ b/examples/spring-hypermedia/src/main/java/io/wcm/caravan/rhyme/examples/spring/hypermedia/Manager.java
@@ -26,19 +26,13 @@ import javax.persistence.OneToMany;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
-import lombok.Data;
-import lombok.Generated;
-import lombok.NoArgsConstructor;
-
 /**
  * @author Greg Turnquist
  */
-@Data
 @Entity
 @EntityListeners(RepositoryModificationListener.class)
-@Generated
-@NoArgsConstructor
 public class Manager {
+
 
   /** a generated ID (to be used in all the link templates) */
   @Id
@@ -59,5 +53,39 @@ public class Manager {
   Manager(String name) {
     this.name = name;
   }
+
+  public Manager() {
+
+  }
+
+  public Long getId() {
+    return this.id;
+  }
+
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+
+  public String getName() {
+    return this.name;
+  }
+
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+
+  public List<Employee> getEmployees() {
+    return this.employees;
+  }
+
+
+  public void setEmployees(List<Employee> employees) {
+    this.employees = employees;
+  }
+
 
 }

--- a/examples/spring-hypermedia/src/main/java/io/wcm/caravan/rhyme/examples/spring/hypermedia/Manager.java
+++ b/examples/spring-hypermedia/src/main/java/io/wcm/caravan/rhyme/examples/spring/hypermedia/Manager.java
@@ -33,7 +33,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 @EntityListeners(RepositoryModificationListener.class)
 public class Manager {
 
-
   /** a generated ID (to be used in all the link templates) */
   @Id
   @GeneratedValue
@@ -55,32 +54,26 @@ public class Manager {
   }
 
   public Manager() {
-
+    // required for deserialization
   }
 
   public Long getId() {
     return this.id;
   }
 
-
   public void setId(Long id) {
     this.id = id;
   }
-
 
   public String getName() {
     return this.name;
   }
 
-
   public void setName(String name) {
     this.name = name;
   }
 
-
   public void setEmployees(List<Employee> employees) {
     this.employees = employees;
   }
-
-
 }

--- a/examples/spring-hypermedia/src/main/java/io/wcm/caravan/rhyme/examples/spring/hypermedia/Manager.java
+++ b/examples/spring-hypermedia/src/main/java/io/wcm/caravan/rhyme/examples/spring/hypermedia/Manager.java
@@ -78,11 +78,6 @@ public class Manager {
   }
 
 
-  public List<Employee> getEmployees() {
-    return this.employees;
-  }
-
-
   public void setEmployees(List<Employee> employees) {
     this.employees = employees;
   }


### PR DESCRIPTION
The spring-hypermedia is using lombok, but the only benefit is the generation of a constructur and getters/setters in two entity classes.

To simplify the initial build in IDes, the lombok dependency should be removed