### PR TITLE
Introduce @ResourceProperty annotation

### DIFF
--- a/api-interfaces/src/main/java/io/wcm/caravan/rhyme/api/annotations/ResourceProperty.java
+++ b/api-interfaces/src/main/java/io/wcm/caravan/rhyme/api/annotations/ResourceProperty.java
@@ -23,11 +23,20 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.Optional;
 
+/**
+ * Identifies a method that allows to access a single JSON property of a HAL resource's state.
+ * The method must provide a value that is serialized as a JSON primitive. This value can either be returned
+ * directly from the annotated method, but can also be wrapped with {@link Optional} or a reactive type.
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface ResourceProperty {
 
+  /**
+   * Allows to override the name of the JSON property (by default it's derived from the method name)
+   * @return the name of the JSON property (or empty string if not overriden)f
+   */
   String value() default "";
-
 }

--- a/api-interfaces/src/main/java/io/wcm/caravan/rhyme/api/annotations/ResourceProperty.java
+++ b/api-interfaces/src/main/java/io/wcm/caravan/rhyme/api/annotations/ResourceProperty.java
@@ -1,0 +1,33 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2021 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.caravan.rhyme.api.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface ResourceProperty {
+
+  String value() default "";
+
+}

--- a/api-interfaces/src/main/java/io/wcm/caravan/rhyme/api/annotations/ResourceState.java
+++ b/api-interfaces/src/main/java/io/wcm/caravan/rhyme/api/annotations/ResourceState.java
@@ -23,11 +23,16 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.Optional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
- * Used to annotate the method that allows to access the state/properties of a HAL resource.
- * The return value of the method must be a reactive single of a JSON node or Java
- * class that matches the JSON object structure (either with public properties or following bean conventions)
+ * Identifies a method that allows to access the state/properties of a HAL resource all at once.
+ * The method must provide a Jackson {@link ObjectNode} or a Java object that that matches the JSON object structure
+ * (and which can be deserialised by a default Jackson {@link ObjectMapper}). This object can either be returned
+ * directly from the annotated method, but can also be wrapped with {@link Optional} or a reactive type.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)

--- a/core/src/main/java/io/wcm/caravan/rhyme/api/spi/HalApiAnnotationSupport.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/api/spi/HalApiAnnotationSupport.java
@@ -67,6 +67,18 @@ public interface HalApiAnnotationSupport {
   boolean isResourceStateMethod(Method method);
 
   /**
+   * @param method from a HAL API interface
+   * @return true if the method returns one of the resource properties
+   */
+  boolean isResourcePropertyMethod(Method method);
+
+  /**
+   * @param method for which {@link #isResourcePropertyMethod(Method)} returns true
+   * @return the name of the property (from the value attribute of the annotation)
+   */
+  String getPropertyName(Method method);
+
+  /**
    * @param method for which {@link #isResourceLinkMethod(Method)} returns true
    * @return the relation to be used for links and embedded resources returned by the method
    */

--- a/core/src/main/java/io/wcm/caravan/rhyme/api/spi/HalApiAnnotationSupport.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/api/spi/HalApiAnnotationSupport.java
@@ -70,13 +70,17 @@ public interface HalApiAnnotationSupport {
    * @param method from a HAL API interface
    * @return true if the method returns one of the resource properties
    */
-  boolean isResourcePropertyMethod(Method method);
+  default boolean isResourcePropertyMethod(Method method) {
+    return false;
+  };
 
   /**
    * @param method for which {@link #isResourcePropertyMethod(Method)} returns true
    * @return the name of the property (from the value attribute of the annotation)
    */
-  String getPropertyName(Method method);
+  default String getPropertyName(Method method) {
+    return null;
+  };
 
   /**
    * @param method for which {@link #isResourceLinkMethod(Method)} returns true

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/HalApiInvocationHandler.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/HalApiInvocationHandler.java
@@ -133,6 +133,16 @@ final class HalApiInvocationHandler implements InvocationHandler {
       return RxJavaReflectionUtils.convertAndCacheReactiveType(state, invocation.getReturnType(), metrics, invocation::getDescription, typeSupport);
     }
 
+    if (invocation.isForMethodAnnotatedWithResourceProperties()) {
+
+      Maybe<Object> property = rxResource
+          .onErrorResumeNext(ex -> addContextToHalApiClientException(ex, invocation))
+          .map(hal -> new ResourcePropertyHandler(hal, typeSupport))
+          .flatMapMaybe(handler -> handler.handleMethodInvocation(invocation));
+
+      return RxJavaReflectionUtils.convertAndCacheReactiveType(property, invocation.getReturnType(), metrics, invocation::getDescription, typeSupport);
+    }
+
     if (invocation.isForMethodAnnotatedWithRelatedResource()) {
 
       Observable<Object> relatedProxies = rxResource

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/HalApiInvocationHandler.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/HalApiInvocationHandler.java
@@ -127,7 +127,7 @@ final class HalApiInvocationHandler implements InvocationHandler {
 
       Maybe<Object> state = rxResource
           .onErrorResumeNext(ex -> addContextToHalApiClientException(ex, invocation))
-          .map(hal -> new ResourceStateHandler(hal))
+          .map(hal -> new ResourceStateHandler(hal, typeSupport))
           .flatMapMaybe(handler -> handler.handleMethodInvocation(invocation));
 
       return RxJavaReflectionUtils.convertAndCacheReactiveType(state, invocation.getReturnType(), metrics, invocation::getDescription, typeSupport);

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/HalApiMethodInvocation.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/HalApiMethodInvocation.java
@@ -83,12 +83,20 @@ class HalApiMethodInvocation {
     return typeSupport.isResourceStateMethod(method);
   }
 
+  boolean isForMethodAnnotatedWithResourceProperties() {
+    return typeSupport.isResourcePropertyMethod(method);
+  }
+
   boolean isForMethodAnnotatedWithResourceRepresentation() {
     return typeSupport.isResourceRepresentationMethod(method);
   }
 
   boolean hasTemplatedReturnType() {
     return method.getGenericReturnType() instanceof ParameterizedType;
+  }
+
+  Method getMethod() {
+    return method;
   }
 
   Class<?> getReturnType() {

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/ResourcePropertyHandler.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/ResourcePropertyHandler.java
@@ -1,0 +1,78 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2021 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.caravan.rhyme.impl.client.proxy;
+
+import static io.wcm.caravan.rhyme.impl.client.proxy.ResourceStateHandler.OBJECT_MAPPER;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import io.reactivex.rxjava3.core.Maybe;
+import io.wcm.caravan.hal.resource.HalResource;
+import io.wcm.caravan.hal.resource.Link;
+import io.wcm.caravan.rhyme.api.annotations.ResourceProperty;
+import io.wcm.caravan.rhyme.api.annotations.ResourceState;
+import io.wcm.caravan.rhyme.api.exceptions.HalApiDeveloperException;
+import io.wcm.caravan.rhyme.impl.reflection.HalApiReflectionUtils;
+import io.wcm.caravan.rhyme.impl.reflection.HalApiTypeSupport;
+
+class ResourcePropertyHandler {
+
+  private final HalResource contextResource;
+  private final HalApiTypeSupport typeSupport;
+
+  ResourcePropertyHandler(HalResource contextResource, HalApiTypeSupport typeSupport) {
+    this.contextResource = contextResource;
+    this.typeSupport = typeSupport;
+  }
+
+  Maybe<Object> handleMethodInvocation(HalApiMethodInvocation invocation) {
+
+    if (typeSupport.isProviderOfMultiplerValues(invocation.getReturnType())) {
+      String msg = "@" + ResourceProperty.class.getSimpleName() + " cannot be used for arrays, but " + invocation + " is using " + invocation.getReturnType()
+          + " as return type. Consider using @" + ResourceState.class.getSimpleName() + " instead";
+      return Maybe.error(new HalApiDeveloperException(msg));
+    }
+
+    String propertyName = HalApiReflectionUtils.getPropertyName(invocation.getMethod(), typeSupport);
+
+    JsonNode jsonNode = contextResource.getModel().path(propertyName);
+
+    if (jsonNode.isMissingNode() || jsonNode.isNull()) {
+
+      if (!typeSupport.isProviderOfOptionalValue(invocation.getReturnType())) {
+
+        String msg = "The JSON property '" + propertyName + "' is " + jsonNode.getNodeType()
+            + ". You must use Maybe or Optional as return type to support this. ";
+
+        Link link = contextResource.getLink();
+        if (link != null) {
+          msg += " (The error was triggered by resource at " + link.getHref() + ")";
+        }
+
+        return Maybe.error(new HalApiDeveloperException(msg));
+      }
+      return Maybe.empty();
+    }
+
+    Object propertyValue = OBJECT_MAPPER.convertValue(jsonNode, invocation.getEmissionType());
+
+    return Maybe.just(propertyValue);
+  }
+}

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/ResourceStateHandler.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/ResourceStateHandler.java
@@ -19,8 +19,6 @@
  */
 package io.wcm.caravan.rhyme.impl.client.proxy;
 
-import java.util.Optional;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,6 +28,7 @@ import com.fasterxml.jackson.datatype.guava.GuavaModule;
 
 import io.reactivex.rxjava3.core.Maybe;
 import io.wcm.caravan.hal.resource.HalResource;
+import io.wcm.caravan.rhyme.impl.reflection.HalApiTypeSupport;
 
 class ResourceStateHandler {
 
@@ -40,9 +39,11 @@ class ResourceStateHandler {
   private static final Logger log = LoggerFactory.getLogger(HalApiInvocationHandler.class);
 
   private final HalResource contextResource;
+  private final HalApiTypeSupport typeSupport;
 
-  ResourceStateHandler(HalResource contextResource) {
+  ResourceStateHandler(HalResource contextResource, HalApiTypeSupport typeSupport) {
     this.contextResource = contextResource;
+    this.typeSupport = typeSupport;
   }
 
   Maybe<Object> handleMethodInvocation(HalApiMethodInvocation invocation) {
@@ -53,7 +54,7 @@ class ResourceStateHandler {
 
     // if the interface is using Maybe or Optional as return type, and the HAL resource does not contain any
     // state properties, then an empty maybe should be returned
-    boolean isOptional = Maybe.class.isAssignableFrom(returnType) || Optional.class.isAssignableFrom(returnType);
+    boolean isOptional = typeSupport.isProviderOfOptionalValue(returnType);
     if (isOptional && contextResource.getStateFieldNames().isEmpty()) {
       return Maybe.empty();
     }

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/ResourceStateHandler.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/ResourceStateHandler.java
@@ -33,7 +33,7 @@ import io.wcm.caravan.hal.resource.HalResource;
 
 class ResourceStateHandler {
 
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+  static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
       .registerModule(new GuavaModule()) // allows de-serialization of Guava collections
       .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/reflection/CompositeHalApiTypeSupport.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/reflection/CompositeHalApiTypeSupport.java
@@ -91,6 +91,18 @@ public class CompositeHalApiTypeSupport implements HalApiTypeSupport {
   }
 
   @Override
+  public boolean isResourcePropertyMethod(Method method) {
+
+    return anyMatch(delegate -> delegate.isResourcePropertyMethod(method));
+  }
+
+  @Override
+  public String getPropertyName(Method method) {
+
+    return firstNonNull(delegate -> delegate.getPropertyName(method));
+  }
+
+  @Override
   public String getRelation(Method method) {
 
     return firstNonNull(delegate -> delegate.getRelation(method));
@@ -123,4 +135,5 @@ public class CompositeHalApiTypeSupport implements HalApiTypeSupport {
   List<HalApiTypeSupport> getDelegates() {
     return delegates;
   }
+
 }

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/reflection/DefaultHalApiTypeSupport.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/reflection/DefaultHalApiTypeSupport.java
@@ -66,7 +66,10 @@ public class DefaultHalApiTypeSupport implements HalApiTypeSupport {
 
   @Override
   public String getPropertyName(Method method) {
-    return method.getAnnotation(ResourceProperty.class).value();
+    if (isResourcePropertyMethod(method)) {
+      return method.getAnnotation(ResourceProperty.class).value();
+    }
+    return null;
   }
 
   @Override

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/reflection/DefaultHalApiTypeSupport.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/reflection/DefaultHalApiTypeSupport.java
@@ -36,6 +36,7 @@ import io.reactivex.rxjava3.core.Single;
 import io.wcm.caravan.rhyme.api.annotations.HalApiInterface;
 import io.wcm.caravan.rhyme.api.annotations.Related;
 import io.wcm.caravan.rhyme.api.annotations.ResourceLink;
+import io.wcm.caravan.rhyme.api.annotations.ResourceProperty;
 import io.wcm.caravan.rhyme.api.annotations.ResourceRepresentation;
 import io.wcm.caravan.rhyme.api.annotations.ResourceState;
 import io.wcm.caravan.rhyme.api.spi.HalApiAnnotationSupport;
@@ -56,6 +57,16 @@ public class DefaultHalApiTypeSupport implements HalApiTypeSupport {
   @Override
   public boolean isResourceStateMethod(Method method) {
     return method.isAnnotationPresent(ResourceState.class);
+  }
+
+  @Override
+  public boolean isResourcePropertyMethod(Method method) {
+    return method.isAnnotationPresent(ResourceProperty.class);
+  }
+
+  @Override
+  public String getPropertyName(Method method) {
+    return method.getAnnotation(ResourceProperty.class).value();
   }
 
   @Override

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/reflection/HalApiReflectionUtils.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/reflection/HalApiReflectionUtils.java
@@ -19,6 +19,7 @@
  */
 package io.wcm.caravan.rhyme.impl.reflection;
 
+import java.beans.Introspector;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -32,6 +33,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import org.apache.commons.lang3.StringUtils;
 
 import com.google.common.collect.Lists;
 
@@ -282,6 +285,23 @@ public final class HalApiReflectionUtils {
       }
 
     }
+  }
+
+  public static String getPropertyName(Method method, HalApiTypeSupport typeSupport) {
+  
+    String fromAnnotation = typeSupport.getPropertyName(method);
+    if (StringUtils.isNotBlank(fromAnnotation)) {
+      return fromAnnotation;
+    }
+  
+    String name = method.getName();
+    if (name.startsWith("get")) {
+      return Introspector.decapitalize(name.substring(3));
+    }
+    if (name.startsWith("is")) {
+      return Introspector.decapitalize(name.substring(2));
+    }
+    return Introspector.decapitalize(name);
   }
 
 }

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/reflection/HalApiReflectionUtils.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/reflection/HalApiReflectionUtils.java
@@ -143,6 +143,18 @@ public final class HalApiReflectionUtils {
   /**
    * @param apiInterface an interface annotated with {@link HalApiInterface} (either directly or by extending)
    * @param annotationSupport the strategy to detect HAL API annotations
+   * @return the method annotated with {@link ResourceState}
+   */
+  public static List<Method> findResourcePropertyMethods(Class<?> apiInterface, HalApiAnnotationSupport annotationSupport) {
+
+    return Stream.of(apiInterface.getMethods())
+        .filter(annotationSupport::isResourcePropertyMethod)
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * @param apiInterface an interface annotated with {@link HalApiInterface} (either directly or by extending)
+   * @param annotationSupport the strategy to detect HAL API annotations
    * @return a list of all methods annotated with {@link Related}
    */
   public static List<Method> getSortedRelatedResourceMethods(Class<?> apiInterface, HalApiAnnotationSupport annotationSupport) {

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/reflection/HalApiTypeSupportAdapter.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/reflection/HalApiTypeSupportAdapter.java
@@ -94,6 +94,16 @@ public class HalApiTypeSupportAdapter implements HalApiTypeSupport {
   }
 
   @Override
+  public boolean isResourcePropertyMethod(Method method) {
+    return annotationSupport.isResourcePropertyMethod(method);
+  }
+
+  @Override
+  public String getPropertyName(Method method) {
+    return annotationSupport.getPropertyName(method);
+  }
+
+  @Override
   public String getRelation(Method method) {
     return annotationSupport.getRelation(method);
   }
@@ -183,9 +193,20 @@ public class HalApiTypeSupportAdapter implements HalApiTypeSupport {
     }
 
     @Override
+    public boolean isResourcePropertyMethod(Method method) {
+      return false;
+    }
+
+    @Override
+    public String getPropertyName(Method method) {
+      return null;
+    }
+
+    @Override
     public String getRelation(Method method) {
       return null;
     }
+
 
   }
 

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/renderer/AsyncHalResourceRendererImpl.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/renderer/AsyncHalResourceRendererImpl.java
@@ -20,18 +20,23 @@
 package io.wcm.caravan.rhyme.impl.renderer;
 
 import static io.wcm.caravan.rhyme.impl.reflection.HalApiReflectionUtils.findHalApiInterface;
-import static io.wcm.caravan.rhyme.impl.reflection.HalApiReflectionUtils.getClassAndMethodName;
 import static io.wcm.caravan.rhyme.impl.reflection.HalApiReflectionUtils.getSimpleClassName;
 
+import java.beans.Introspector;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Optional;
 
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
+
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Preconditions;
 
+import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.core.Single;
 import io.wcm.caravan.hal.resource.HalResource;
 import io.wcm.caravan.rhyme.api.common.RequestMetricsCollector;
@@ -84,7 +89,7 @@ public final class AsyncHalResourceRendererImpl implements AsyncHalResourceRende
       Class<?> apiInterface = findHalApiInterface(resourceImplInstance, typeSupport);
 
       // get the JSON resource state from the method annotated with @ResourceState
-      Single<ObjectNode> rxState = renderResourceState(apiInterface, resourceImplInstance);
+      Single<ObjectNode> rxState = renderResourceStateAndProperties(apiInterface, resourceImplInstance);
 
       // render links and embedded resources for each method annotated with @RelatedResource
       Single<List<RelationRenderResult>> rxRelated = relatedRenderer.renderRelated(apiInterface, resourceImplInstance);
@@ -100,6 +105,22 @@ public final class AsyncHalResourceRendererImpl implements AsyncHalResourceRende
 
       return rxHalResource;
     }
+  }
+
+  Single<ObjectNode> renderResourceStateAndProperties(Class<?> apiInterface, Object resourceImplInstance) {
+
+    Single<ObjectNode> rxState = renderResourceState(apiInterface, resourceImplInstance);
+
+    Single<List<Pair<String, JsonNode>>> rxProperties = renderResourceProperties(apiInterface, resourceImplInstance).toList();
+
+    return Single.zip(rxState, rxProperties, (state, properties) -> {
+
+      properties.forEach(pair -> state.set(pair.getKey(), pair.getValue()));
+
+      return state;
+    })
+        // and measure the total time of the emissions
+        .compose(EmissionStopwatch.collectMetrics(() -> "rendering resource state of " + getSimpleClassName(resourceImplInstance, typeSupport), metrics));
   }
 
   Single<ObjectNode> renderResourceState(Class<?> apiInterface, Object resourceImplInstance) {
@@ -118,11 +139,38 @@ public final class AsyncHalResourceRendererImpl implements AsyncHalResourceRende
         .map(object -> OBJECT_MAPPER.convertValue(object, ObjectNode.class))
         // or use an empty object if the method returned an empty Maybe or Observable
         .singleElement()
-        .switchIfEmpty(emptyObject)
-        // and measure the total time of the emissions
-        .compose(
-            EmissionStopwatch.collectMetrics(() -> "rendering state emitted by " + getClassAndMethodName(resourceImplInstance, method.get(), typeSupport),
-                metrics));
+        .switchIfEmpty(emptyObject);
+  }
+
+  private Observable<Pair<String, JsonNode>> renderResourceProperties(Class<?> apiInterface, Object resourceImplInstance) {
+
+    List<Method> methods = HalApiReflectionUtils.findResourcePropertyMethods(apiInterface, typeSupport);
+
+    return Observable.fromIterable(methods)
+        .flatMap(method -> {
+          return RxJavaReflectionUtils.invokeMethodAndReturnObservable(resourceImplInstance, method, metrics, typeSupport)
+              // convert the emitted property value to a JSON  node
+              .map(object -> OBJECT_MAPPER.convertValue(object, JsonNode.class))
+              .map(returnValue -> Pair.of(getPropertyName(method), returnValue));
+        });
+  }
+
+
+  private String getPropertyName(Method method) {
+
+    String fromAnnotation = typeSupport.getPropertyName(method);
+    if (StringUtils.isNotBlank(fromAnnotation)) {
+      return fromAnnotation;
+    }
+
+    String name = method.getName();
+    if (name.startsWith("get")) {
+      return Introspector.decapitalize(name.substring(3));
+    }
+    if (name.startsWith("is")) {
+      return Introspector.decapitalize(name.substring(2));
+    }
+    return Introspector.decapitalize(name);
   }
 
   HalResource createHalResource(Object resourceImplInstance, ObjectNode stateNode, List<RelationRenderResult> listOfRelated) {

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/renderer/AsyncHalResourceRendererImpl.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/renderer/AsyncHalResourceRendererImpl.java
@@ -22,12 +22,10 @@ package io.wcm.caravan.rhyme.impl.renderer;
 import static io.wcm.caravan.rhyme.impl.reflection.HalApiReflectionUtils.findHalApiInterface;
 import static io.wcm.caravan.rhyme.impl.reflection.HalApiReflectionUtils.getSimpleClassName;
 
-import java.beans.Introspector;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Optional;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -147,31 +145,17 @@ public final class AsyncHalResourceRendererImpl implements AsyncHalResourceRende
     List<Method> methods = HalApiReflectionUtils.findResourcePropertyMethods(apiInterface, typeSupport);
 
     return Observable.fromIterable(methods)
-        .flatMap(method -> {
+        .concatMap(method -> {
+
+          String propertyName = HalApiReflectionUtils.getPropertyName(method, typeSupport);
+
           return RxJavaReflectionUtils.invokeMethodAndReturnObservable(resourceImplInstance, method, metrics, typeSupport)
               // convert the emitted property value to a JSON  node
-              .map(object -> OBJECT_MAPPER.convertValue(object, JsonNode.class))
-              .map(returnValue -> Pair.of(getPropertyName(method), returnValue));
+              .map(returnValue -> OBJECT_MAPPER.convertValue(returnValue, JsonNode.class))
+              .map(jsonNode -> Pair.of(propertyName, jsonNode));
         });
   }
 
-
-  private String getPropertyName(Method method) {
-
-    String fromAnnotation = typeSupport.getPropertyName(method);
-    if (StringUtils.isNotBlank(fromAnnotation)) {
-      return fromAnnotation;
-    }
-
-    String name = method.getName();
-    if (name.startsWith("get")) {
-      return Introspector.decapitalize(name.substring(3));
-    }
-    if (name.startsWith("is")) {
-      return Introspector.decapitalize(name.substring(2));
-    }
-    return Introspector.decapitalize(name);
-  }
 
   HalResource createHalResource(Object resourceImplInstance, ObjectNode stateNode, List<RelationRenderResult> listOfRelated) {
 

--- a/core/src/test/java/io/wcm/caravan/rhyme/api/spi/HalApiAnnotationSupportTest.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/api/spi/HalApiAnnotationSupportTest.java
@@ -1,0 +1,82 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2022 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.caravan.rhyme.api.spi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.Test;
+
+public class HalApiAnnotationSupportTest {
+
+  private final HalApiAnnotationSupport annotationSupport = new HalApiAnnotationSupport() {
+
+    @Override
+    public boolean isHalApiInterface(Class<?> type) {
+      return false;
+    }
+
+    @Override
+    public String getContentType(Class<?> halApiInterface) {
+      return null;
+    }
+
+    @Override
+    public boolean isResourceLinkMethod(Method method) {
+      return false;
+    }
+
+    @Override
+    public boolean isResourceRepresentationMethod(Method method) {
+      return false;
+    }
+
+    @Override
+    public boolean isRelatedResourceMethod(Method method) {
+      return false;
+    }
+
+    @Override
+    public boolean isResourceStateMethod(Method method) {
+      return false;
+    }
+
+    @Override
+    public String getRelation(Method method) {
+      return null;
+    }
+
+  };
+
+  @Test
+  void should_have_default_implementation_for_isResourcePropertyMethod() {
+
+    assertThat(annotationSupport.isResourcePropertyMethod(null))
+        .isEqualTo(false);
+  }
+
+  @Test
+  void should_have_default_implementation_for_getProeprtyName() {
+
+    assertThat(annotationSupport.getPropertyName(null))
+        .isNull();
+  }
+}

--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/RhymeBuilderImplTest.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/RhymeBuilderImplTest.java
@@ -410,6 +410,16 @@ public class RhymeBuilderImplTest {
     }
 
     @Override
+    public boolean isResourcePropertyMethod(Method method) {
+      return false;
+    }
+
+    @Override
+    public String getPropertyName(Method method) {
+      return null;
+    }
+
+    @Override
     public String getRelation(Method method) {
 
       if (isRelatedResourceMethod(method)) {

--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/client/ResourcePropertyTest.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/client/ResourcePropertyTest.java
@@ -32,6 +32,7 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
+import io.wcm.caravan.hal.resource.HalResource;
 import io.wcm.caravan.rhyme.api.annotations.HalApiInterface;
 import io.wcm.caravan.rhyme.api.annotations.ResourceProperty;
 import io.wcm.caravan.rhyme.api.exceptions.HalApiDeveloperException;
@@ -144,13 +145,14 @@ public class ResourcePropertyTest {
 
     assertThat(ex)
         .isInstanceOf(HalApiDeveloperException.class)
-        .hasMessageStartingWith("The JSON property 'text' is NULL");
+        .hasMessageStartingWith("The JSON property 'text' is NULL")
+        .hasMessageEndingWith("(The error was triggered by resource at /)");
   }
 
   @Test
   public void should_throw_developer_exception_for_missing_values() throws Exception {
 
-    client.mockHalResponseWithState(ENTRY_POINT_URI, JsonNodeFactory.instance.objectNode());
+    client.mockHalResponse(ENTRY_POINT_URI, new HalResource());
 
     ResourceWithRenamedProperties proxy = client.createProxy(ResourceWithRenamedProperties.class);
 

--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/client/ResourcePropertyTest.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/client/ResourcePropertyTest.java
@@ -1,0 +1,202 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2021 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.caravan.rhyme.impl.client;
+
+import static io.wcm.caravan.rhyme.impl.client.ClientTestSupport.ENTRY_POINT_URI;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import java.util.List;
+import java.util.concurrent.Future;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+import io.wcm.caravan.rhyme.api.annotations.HalApiInterface;
+import io.wcm.caravan.rhyme.api.annotations.ResourceProperty;
+import io.wcm.caravan.rhyme.api.exceptions.HalApiDeveloperException;
+import io.wcm.caravan.rhyme.impl.client.ClientTestSupport.MockClientTestSupport;
+import io.wcm.caravan.rhyme.testing.resources.TestResourceState;
+
+
+public class ResourcePropertyTest {
+
+  private final MockClientTestSupport client = ClientTestSupport.withMocking();
+
+  @HalApiInterface
+  interface ResourceWithSingleProperties {
+
+    @ResourceProperty
+    Single<String> getText();
+
+
+    @ResourceProperty
+    Single<Integer> getNumber();
+  }
+
+  @Test
+  public void single_resource_properties_should_be_emitted() throws Exception {
+
+    client.mockHalResponseWithState(ENTRY_POINT_URI, new TestResourceState().withText("test").withNumber(1234));
+
+    ResourceWithSingleProperties proxy = client.createProxy(ResourceWithSingleProperties.class);
+
+    assertThat(proxy.getText().blockingGet())
+        .isEqualTo("test");
+
+    assertThat(proxy.getNumber().blockingGet())
+        .isEqualTo(1234);
+  }
+
+
+  @HalApiInterface
+  interface ResourceWithMaybeProperties {
+
+    @ResourceProperty
+    Maybe<String> getText();
+
+
+    @ResourceProperty
+    Maybe<Integer> getNumber();
+  }
+
+  @Test
+  public void maybe_resource_state_should_be_emitted() throws Exception {
+
+    client.mockHalResponseWithState(ENTRY_POINT_URI, new TestResourceState().withText("test").withNumber(1234));
+
+    ResourceWithMaybeProperties proxy = client.createProxy(ResourceWithMaybeProperties.class);
+
+    assertThat(proxy.getText().blockingGet())
+        .isEqualTo("test");
+
+    assertThat(proxy.getNumber().blockingGet())
+        .isEqualTo(1234);
+  }
+
+  @Test
+  public void maybe_resource_state_should_be_empty_if_no_properties_are_set() throws Exception {
+
+    client.mockHalResponseWithState(ENTRY_POINT_URI, JsonNodeFactory.instance.objectNode());
+
+    ResourceWithMaybeProperties proxy = client.createProxy(ResourceWithMaybeProperties.class);
+
+    assertThat(proxy.getText().isEmpty().blockingGet())
+        .isTrue();
+
+    assertThat(proxy.getNumber().isEmpty().blockingGet())
+        .isTrue();
+  }
+
+  @HalApiInterface
+  interface ResourceWithRenamedProperties {
+
+    @ResourceProperty("text")
+    String getString();
+
+
+    @ResourceProperty("number")
+    Integer getInteger();
+  }
+
+  @Test
+  public void should_use_names_from_annotation() throws Exception {
+
+    client.mockHalResponseWithState(ENTRY_POINT_URI, new TestResourceState().withText("test").withNumber(1234));
+
+    ResourceWithRenamedProperties proxy = client.createProxy(ResourceWithRenamedProperties.class);
+
+    assertThat(proxy.getString())
+        .isEqualTo("test");
+
+    assertThat(proxy.getInteger())
+        .isEqualTo(1234);
+  }
+
+  @Test
+  public void should_throw_developer_exception_for_null_values() throws Exception {
+
+    client.mockHalResponseWithState(ENTRY_POINT_URI, new TestResourceState());
+
+    ResourceWithRenamedProperties proxy = client.createProxy(ResourceWithRenamedProperties.class);
+
+    Throwable ex = catchThrowable(() -> proxy.getString());
+
+    assertThat(ex)
+        .isInstanceOf(HalApiDeveloperException.class)
+        .hasMessageStartingWith("The JSON property 'text' is NULL");
+  }
+
+  @Test
+  public void should_throw_developer_exception_for_missing_values() throws Exception {
+
+    client.mockHalResponseWithState(ENTRY_POINT_URI, JsonNodeFactory.instance.objectNode());
+
+    ResourceWithRenamedProperties proxy = client.createProxy(ResourceWithRenamedProperties.class);
+
+    Throwable ex = catchThrowable(() -> proxy.getString());
+
+    assertThat(ex)
+        .isInstanceOf(HalApiDeveloperException.class)
+        .hasMessageStartingWith("The JSON property 'text' is MISSING");
+  }
+
+  @HalApiInterface
+  interface ResourceWithListProperty {
+
+    @ResourceProperty
+    List<String> getStrings();
+  }
+
+  @Test
+  public void should_throw_developer_exception_if_using_list_return_type() throws Exception {
+
+    client.mockHalResponseWithState(ENTRY_POINT_URI, JsonNodeFactory.instance.objectNode());
+
+    ResourceWithListProperty proxy = client.createProxy(ResourceWithListProperty.class);
+
+    Throwable ex = catchThrowable(() -> proxy.getStrings());
+
+    assertThat(ex)
+        .isInstanceOf(HalApiDeveloperException.class)
+        .hasMessageStartingWith("@ResourceProperty cannot be used for arrays");
+  }
+
+  @HalApiInterface
+  interface ResourceWithIllegalReturnType {
+
+    @ResourceProperty
+    Future<TestResourceState> notSupported();
+  }
+
+  @Test
+  public void should_throw_developer_exception_if_return_type_is_not_supported() {
+
+    Throwable ex = catchThrowable(
+        () -> client.createProxy(ResourceWithIllegalReturnType.class).notSupported());
+
+    assertThat(ex).isInstanceOf(HalApiDeveloperException.class)
+        .hasMessageStartingWith("The return type Future of method ResourceWithIllegalReturnType#notSupported is not supported.");
+  }
+
+}

--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/reflection/CompositeHalApiTypeSupportTest.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/reflection/CompositeHalApiTypeSupportTest.java
@@ -226,6 +226,19 @@ public class CompositeHalApiTypeSupportTest {
   }
 
   @Test
+  public void isResourcePropertyMethod_should_return_first_true_value() throws Exception {
+
+    assertThatCompositeReturnsFirstTrueValueOfMock(a -> a.isResourcePropertyMethod(firstMethod));
+  }
+
+  @Test
+  public void getPropertyName_should_return_first_non_null_value() throws Exception {
+
+    assertThatCompositeReturnsFirstNonNullValueOfMock(a -> a.getPropertyName(firstMethod), "prop");
+  }
+
+
+  @Test
   public void convertFromObservable_should_return_first_non_null_value() throws Exception {
 
     Function<Observable, Iterator> fun = o -> ((List)o.toList().blockingGet()).iterator();

--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/renderer/RenderResourcePropertyTest.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/renderer/RenderResourcePropertyTest.java
@@ -1,0 +1,199 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2022 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.caravan.rhyme.impl.renderer;
+
+import static io.wcm.caravan.rhyme.impl.renderer.AsyncHalResourceRendererTestUtil.createTestState;
+import static io.wcm.caravan.rhyme.impl.renderer.AsyncHalResourceRendererTestUtil.render;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+import io.wcm.caravan.hal.resource.HalResource;
+import io.wcm.caravan.rhyme.api.annotations.HalApiInterface;
+import io.wcm.caravan.rhyme.api.annotations.ResourceProperty;
+import io.wcm.caravan.rhyme.api.annotations.ResourceState;
+import io.wcm.caravan.rhyme.testing.TestState;
+
+public class RenderResourcePropertyTest {
+
+  @HalApiInterface
+  public interface TestResourceWithSingleProperties {
+
+    @ResourceProperty
+    Single<String> getString();
+
+    @ResourceProperty
+    Single<Integer> getNumber();
+  }
+
+  @Test
+  public void single_resource_properties_should_be_rendered() {
+
+    TestState state = createTestState();
+
+    TestResourceWithSingleProperties resourceImpl = new TestResourceWithSingleProperties() {
+
+      @Override
+      public Single<String> getString() {
+        return Single.just(state.string);
+      }
+
+      @Override
+      public Single<Integer> getNumber() {
+        return Single.just(state.number);
+      }
+    };
+
+    HalResource hal = render(resourceImpl);
+
+    assertThat(hal.adaptTo(TestState.class))
+        .isEqualToComparingFieldByField(state);
+  }
+
+
+  @HalApiInterface
+  public interface TestResourceWithMaybeProperties {
+
+    @ResourceProperty
+    Maybe<String> getString();
+
+    @ResourceProperty
+    Maybe<Integer> getNumber();
+  }
+
+  @Test
+  public void maybe_resource_properties_should_be_rendered_if_value_is_available() {
+
+    TestResourceWithMaybeProperties resourceImpl = new TestResourceWithMaybeProperties() {
+
+      @Override
+      public Maybe<String> getString() {
+        return Maybe.just("foo");
+      }
+
+      @Override
+      public Maybe<Integer> getNumber() {
+        return Maybe.empty();
+      }
+    };
+
+    JsonNode json = render(resourceImpl).getModel();
+
+    assertThat(json.path("string").asText())
+        .isEqualTo("foo");
+
+    assertThat(json.path("number").isMissingNode())
+        .isTrue();
+  }
+
+
+  @HalApiInterface
+  public interface TestResourceWithNamedProperties {
+
+    @ResourceProperty("foo")
+    String getString();
+
+    @ResourceProperty
+    String bar();
+
+    @ResourceProperty
+    Boolean isValid();
+  }
+
+  @Test
+  public void property_names_should_be_taken_from_annotation_or_derived_from_method() {
+
+    TestResourceWithNamedProperties resourceImpl = new TestResourceWithNamedProperties() {
+
+      @Override
+      public String getString() {
+        return "foo";
+      }
+
+      @Override
+      public String bar() {
+        return "bar";
+      }
+
+      @Override
+      public Boolean isValid() {
+        return true;
+      }
+    };
+
+    JsonNode json = render(resourceImpl).getModel();
+
+    assertThat(() -> json.fieldNames())
+        .containsExactlyInAnyOrder("foo", "bar", "valid");
+  }
+
+  @HalApiInterface
+  public interface TestResourceWithStateAndProperties {
+
+    @ResourceState
+    TestState getState();
+
+    @ResourceProperty
+    Integer getNumber();
+
+    @ResourceProperty
+    Boolean isValid();
+  }
+
+  @Test
+  public void properties_should_be_merged_with_state() {
+
+    TestState state = createTestState();
+
+    TestResourceWithStateAndProperties resourceImpl = new TestResourceWithStateAndProperties() {
+
+      @Override
+      public TestState getState() {
+        return state;
+      }
+
+      @Override
+      public Integer getNumber() {
+        return 1234;
+      }
+
+      @Override
+      public Boolean isValid() {
+        return true;
+      }
+    };
+
+    JsonNode json = render(resourceImpl).getModel();
+
+    assertThat(json.path("string").asText())
+        .isEqualTo(state.string);
+
+    // the return value from #getNumber should overwrite the property from TestState
+    assertThat(json.path("number").asInt())
+        .isEqualTo(resourceImpl.getNumber());
+
+    assertThat(json.path("valid").asBoolean())
+        .isEqualTo(resourceImpl.isValid());
+  }
+}

--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/renderer/RenderResourcePropertyTest.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/renderer/RenderResourcePropertyTest.java
@@ -145,9 +145,9 @@ public class RenderResourcePropertyTest {
       }
     };
 
-    JsonNode json = render(resourceImpl).getModel();
+    HalResource hal = render(resourceImpl);
 
-    assertThat(() -> json.fieldNames())
+    assertThat(hal.getStateFieldNames())
         .containsExactlyInAnyOrder("foo", "bar", "valid");
   }
 

--- a/core/src/test/java/io/wcm/caravan/rhyme/testing/resources/TestResourceState.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/testing/resources/TestResourceState.java
@@ -28,5 +28,10 @@ public class TestResourceState {
     this.text = value;
     return this;
   }
+
+  public TestResourceState withNumber(Integer value) {
+    this.number = value;
+    return this;
+  }
 }
 

--- a/examples/osgi-jaxrs-example-service/pom.xml
+++ b/examples/osgi-jaxrs-example-service/pom.xml
@@ -46,19 +46,7 @@
   <dependencies>
     <dependency>
       <groupId>io.wcm.caravan</groupId>
-      <artifactId>io.wcm.caravan.rhyme.api-interfaces</artifactId>
-      <version>1.0.0</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.wcm.caravan</groupId>
       <artifactId>io.wcm.caravan.rhyme.osgi-jaxrs</artifactId>
-      <version>1.1.0-SNAPSHOT</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.wcm.caravan</groupId>
-      <artifactId>io.wcm.caravan.rhyme.core</artifactId>
       <version>1.1.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>

--- a/integration/aem/pom.xml
+++ b/integration/aem/pom.xml
@@ -51,12 +51,6 @@
     <!-- wcm.io -->
     <dependency>
       <groupId>io.wcm.caravan</groupId>
-      <artifactId>io.wcm.caravan.rhyme.api-interfaces</artifactId>
-      <version>1.0.0</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.wcm.caravan</groupId>
       <artifactId>io.wcm.caravan.rhyme.core</artifactId>
       <version>1.1.0-SNAPSHOT</version>
       <scope>compile</scope>

--- a/integration/osgi-jaxrs/pom.xml
+++ b/integration/osgi-jaxrs/pom.xml
@@ -51,12 +51,6 @@
     <!-- wcm.io -->
     <dependency>
       <groupId>io.wcm.caravan</groupId>
-      <artifactId>io.wcm.caravan.rhyme.api-interfaces</artifactId>
-      <version>1.0.0</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.wcm.caravan</groupId>
       <artifactId>io.wcm.caravan.rhyme.core</artifactId>
       <version>1.1.0-SNAPSHOT</version>
       <scope>compile</scope>

--- a/tooling/docs-maven-plugin/pom.xml
+++ b/tooling/docs-maven-plugin/pom.xml
@@ -62,13 +62,6 @@
   
     <dependency>
       <groupId>io.wcm.caravan</groupId>
-      <artifactId>io.wcm.caravan.rhyme.api-interfaces</artifactId>
-      <version>1.0.0</version>
-      <scope>compile</scope>
-    </dependency>
-    
-    <dependency>
-      <groupId>io.wcm.caravan</groupId>
       <artifactId>io.wcm.caravan.rhyme.core</artifactId>
       <version>1.1.0-SNAPSHOT</version>
       <scope>compile</scope>

--- a/tooling/docs-maven-plugin/src/test/java/io/wcm/caravan/maven/plugins/rhymedocs/model/RhymeApiDocsTest.java
+++ b/tooling/docs-maven-plugin/src/test/java/io/wcm/caravan/maven/plugins/rhymedocs/model/RhymeApiDocsTest.java
@@ -53,7 +53,8 @@ public class RhymeApiDocsTest {
       RhymePropertiesDocsTest.ResourceWithPropertiesWithoutSource.class,
       RhymePropertiesDocsTest.ResourceWithAnnotatedProperties.class,
       RhymePropertiesDocsTest.ResourceWithJsonIgnoreAnnotation.class,
-      RhymePropertiesDocsTest.ResourceWithPrivateFieldsAndBeanProperties.class
+      RhymePropertiesDocsTest.ResourceWithPrivateFieldsAndBeanProperties.class,
+      RhymePropertiesDocsTest.ResourceWithResourceProperty.class
   };
 
   static RhymeApiDocs getApiDocs() {

--- a/tooling/docs-maven-plugin/src/test/java/io/wcm/caravan/maven/plugins/rhymedocs/model/RhymePropertiesDocsTest.java
+++ b/tooling/docs-maven-plugin/src/test/java/io/wcm/caravan/maven/plugins/rhymedocs/model/RhymePropertiesDocsTest.java
@@ -41,6 +41,7 @@ import io.wcm.caravan.maven.plugins.rhymedocs.interfaces.ResourceWithRxBeanPrope
 import io.wcm.caravan.maven.plugins.rhymedocs.interfaces.ResourceWithRxBeanProperties.BeanProperties;
 import io.wcm.caravan.maven.plugins.rhymedocs.interfaces.RhymeDocTestEntryPoint;
 import io.wcm.caravan.rhyme.api.annotations.HalApiInterface;
+import io.wcm.caravan.rhyme.api.annotations.ResourceProperty;
 import io.wcm.caravan.rhyme.api.annotations.ResourceState;
 
 public class RhymePropertiesDocsTest {
@@ -627,5 +628,39 @@ public class RhymePropertiesDocsTest {
       }
 
     }
+  }
+
+  @Test
+  public void getProperties_should_use_javadocs_from_ResourceProperty() {
+
+    RhymeResourceDocs docs = getDocsFor(ResourceWithResourceProperty.class);
+
+    assertThat(docs.getProperties())
+        .extracting(RhymePropertyDocs::getJsonPointer)
+        .containsExactly(
+            "/title", "/foo");
+
+    assertThat(findDocsForProperty("/title", docs).getDescription())
+        .isEqualTo("the title");
+
+    assertThat(findDocsForProperty("/foo", docs).getDescription())
+        .isEqualTo("the index");
+  }
+
+  @HalApiInterface
+  interface ResourceWithResourceProperty {
+
+    /**
+     * @return the title
+     */
+    @ResourceProperty
+    String getTitle();
+
+    /**
+     * the index
+     * @return an integer
+     */
+    @ResourceProperty("foo")
+    Integer getIndex();
   }
 }


### PR DESCRIPTION
For resources that only have a few properties, it's annoying that you have to create additional classes or interfaces to use the @ResourceState annotation

This PR adds an alternative ResourceProperty annotation that can be used to define multiple primitive properties directly in the HalApiInterface