### PR TITLE
Require opt-in for generation of embedded "rhyme:metadata" resource

### DIFF
--- a/core/src/main/java/io/wcm/caravan/rhyme/api/RhymeBuilder.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/api/RhymeBuilder.java
@@ -112,6 +112,13 @@ public interface RhymeBuilder {
   RhymeBuilder withExceptionStrategy(ExceptionStatusAndLoggingStrategy customStrategy);
 
   /**
+   * Enables the capturing of extensive performance and upstream response metadata for this request,
+   * which will be included as an embedded resource in the response.
+   * @return this
+   */
+  RhymeBuilder withEmbeddedMetadata();
+
+  /**
    * Create the {@link Rhyme} instance to be used to throughout the lifecycle of an incoming request
    * @param incomingRequestUri URI of the incoming request (can be absolute or relative, depending on the
    *          platform/framework)

--- a/core/src/main/java/io/wcm/caravan/rhyme/api/client/HalApiClientBuilder.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/api/client/HalApiClientBuilder.java
@@ -34,7 +34,7 @@ import io.wcm.caravan.rhyme.impl.renderer.AsyncHalResourceRenderer;
  * A fluent builder to create and customize {@link HalApiClient} instances for advanced integration or test scenarios.
  * <p>
  * If you don't need any of the advanced customizations, you can simply use {@link HalApiClient#create()}
- * {@link HalApiClient#create(HalResourceLoader)} instead.
+ * or {@link HalApiClient#create(HalResourceLoader)} instead.
  * </p>
  * <p>
  * {@link HalApiClientBuilder} instances shouldn't be re-used, as calling the build method may modify its state.

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/AbstractRhymeBuilder.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/AbstractRhymeBuilder.java
@@ -118,6 +118,13 @@ abstract class AbstractRhymeBuilder<BuilderInterface> {
     return (BuilderInterface)this;
   }
 
+  @SuppressWarnings("unchecked")
+  public BuilderInterface withEmbeddedMetadata() {
+
+    this.metrics = RequestMetricsCollector.create();
+    return (BuilderInterface)this;
+  }
+
   private ExceptionStatusAndLoggingStrategy getEffectiveExceptionStrategy() {
 
     List<ExceptionStatusAndLoggingStrategy> nonNullStrategies = exceptionStrategies.stream()
@@ -159,7 +166,7 @@ abstract class AbstractRhymeBuilder<BuilderInterface> {
     }
 
     if (metrics == null) {
-      metrics = RequestMetricsCollector.create();
+      metrics = RequestMetricsCollector.createEssentialCollector();
     }
   }
 

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/metadata/MaxAgeOnlyCollector.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/metadata/MaxAgeOnlyCollector.java
@@ -1,0 +1,132 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2022 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.caravan.rhyme.impl.metadata;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+
+import org.apache.commons.lang3.ObjectUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.wcm.caravan.hal.resource.HalResource;
+import io.wcm.caravan.rhyme.api.common.RequestMetricsCollector;
+import io.wcm.caravan.rhyme.api.common.RequestMetricsStopwatch;
+import io.wcm.caravan.rhyme.api.resources.LinkableResource;
+import io.wcm.caravan.rhyme.impl.metadata.FullMetadataGenerator.TimeMeasurement;
+
+/**
+ * Minimal implementation of {@link RequestMetricsCollector} containing only the essential functionality required for
+ * calculation of the max-age header to work
+ */
+public class MaxAgeOnlyCollector implements RequestMetricsCollector {
+
+  private static final Logger log = LoggerFactory.getLogger(MaxAgeOnlyCollector.class);
+
+  private final AtomicBoolean metadataWasRendered = new AtomicBoolean();
+
+  private final List<TimeMeasurement> inputMaxAgeSeconds = Collections.synchronizedList(new ArrayList<>());
+
+  private Integer maxAgeLimit;
+
+  @Override
+  public void onResponseRetrieved(String resourceUri, String resourceTitle, Integer maxAgeSeconds, long responseTimeMicros) {
+
+    if (metadataWasRendered.get()) {
+      log.warn("Response from {} was retrieved after embedded metadata resource was rendered", resourceUri);
+      return;
+    }
+
+    if (maxAgeSeconds != null) {
+      inputMaxAgeSeconds.add(new TimeMeasurement(resourceUri, maxAgeSeconds / 1.f, TimeUnit.SECONDS));
+    }
+  }
+
+  @Override
+  public void setResponseMaxAge(Duration duration) {
+
+    long seconds = duration.getSeconds();
+    int intSeconds = seconds > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int)seconds;
+
+    if (maxAgeLimit != null) {
+      maxAgeLimit = Math.min(maxAgeLimit, intSeconds);
+    }
+    else {
+      maxAgeLimit = intSeconds;
+    }
+  }
+
+  /**
+   * @return the min max-age value of all responses that have been retrieved, or 365 days if no responses have been
+   *         fetched, or none of them had a max-age header
+   */
+  @Override
+  public Integer getResponseMaxAge() {
+
+    if (maxAgeLimit == null && inputMaxAgeSeconds.isEmpty()) {
+      return null;
+    }
+
+    int upperLimit = ObjectUtils.defaultIfNull(maxAgeLimit, (int)TimeUnit.DAYS.toSeconds(365));
+
+    // find the max-age values of all requested resources
+    int inputMaxAge = inputMaxAgeSeconds.stream()
+        .mapToInt(maxAge -> Math.round(maxAge.getTime()))
+        // get the smallest max age time
+        .min()
+        // or fall back to the upper limit if no resources were retrieved
+        .orElse(upperLimit);
+
+    return Math.min(inputMaxAge, upperLimit);
+  }
+
+  List<TimeMeasurement> getSortedInputMaxAgeSeconds() {
+    return TimeMeasurement.LONGEST_TIME_FIRST.sortedCopy(inputMaxAgeSeconds);
+  }
+
+  @Override
+  public HalResource createMetadataResource(LinkableResource resourceImpl) {
+
+    metadataWasRendered.set(true);
+
+    return null;
+  }
+
+  @Override
+  public void onMethodInvocationFinished(Class category, String methodDescription, long invocationDurationMicros) {
+    // ignore all measurements
+  }
+
+  @Override
+  public RequestMetricsStopwatch startStopwatch(Class measuringClass, Supplier<String> taskDescription) {
+    return new RequestMetricsStopwatch() {
+
+      @Override
+      public void close() {
+        // ignore all measurements
+      }
+    };
+  }
+}

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/metadata/ResponseMetadataRelations.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/metadata/ResponseMetadataRelations.java
@@ -21,7 +21,7 @@ package io.wcm.caravan.rhyme.impl.metadata;
 
 /**
  * Constants for the relation used in the embedded metadata resource created by
- * {@link ResponseMetadataGenerator#createMetadataResource(io.wcm.caravan.rhyme.api.resources.LinkableResource)}
+ * {@link FullMetadataGenerator#createMetadataResource(io.wcm.caravan.rhyme.api.resources.LinkableResource)}
  */
 public final class ResponseMetadataRelations {
 

--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/RhymeImplTest.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/RhymeImplTest.java
@@ -202,9 +202,14 @@ public class RhymeImplTest {
   @Test
   public void startStopwatch_should_start_a_measurement_that_shows_up_in_metadata() throws Exception {
 
-    MeasuringTestResource resourceImpl = new MeasuringTestResource();
+    Rhyme rhymeWithMetadata = RhymeBuilder
+        .create()
+        .withEmbeddedMetadata()
+        .buildForRequestTo(INCOMING_REQUEST_URI);
 
-    HalResponse response = rhyme.renderResponse(resourceImpl).blockingGet();
+    MeasuringTestResource resourceImpl = new MeasuringTestResource(rhymeWithMetadata);
+
+    HalResponse response = rhymeWithMetadata.renderResponse(resourceImpl).blockingGet();
 
     HalResource metadata = response.getBody().getEmbeddedResource(RHYME_METADATA_RELATION);
     assertThat(metadata).isNotNull();
@@ -224,7 +229,13 @@ public class RhymeImplTest {
         .endsWith("- 1x invocation of #createLink");
   }
 
-  class MeasuringTestResource implements LinkableTestResource {
+  static class MeasuringTestResource implements LinkableTestResource {
+
+    private final Rhyme rhyme;
+
+    MeasuringTestResource(Rhyme rhyme) {
+      this.rhyme = rhyme;
+    }
 
     @Override
     public Link createLink() {
@@ -233,6 +244,5 @@ public class RhymeImplTest {
         return new Link("/foo");
       }
     }
-
   }
 }

--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/metadata/ResponseMetadataGeneratorTest.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/metadata/ResponseMetadataGeneratorTest.java
@@ -42,7 +42,7 @@ import io.wcm.caravan.hal.resource.Link;
 import io.wcm.caravan.rhyme.api.client.HalApiClient;
 import io.wcm.caravan.rhyme.api.resources.LinkableResource;
 import io.wcm.caravan.rhyme.api.server.AsyncHalResponseRenderer;
-import io.wcm.caravan.rhyme.impl.metadata.ResponseMetadataGenerator.TimeMeasurement;
+import io.wcm.caravan.rhyme.impl.metadata.FullMetadataGenerator.TimeMeasurement;
 
 @ExtendWith(MockitoExtension.class)
 public class ResponseMetadataGeneratorTest {
@@ -59,7 +59,7 @@ public class ResponseMetadataGeneratorTest {
   @Mock
   private LinkableResource resource;
 
-  private final ResponseMetadataGenerator metrics = new ResponseMetadataGenerator();
+  private final FullMetadataGenerator metrics = new FullMetadataGenerator();
 
   @Test
   public void default_output_max_age_should_be_null() throws Exception {

--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/renderer/AsyncHalResourceRendererTestUtil.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/renderer/AsyncHalResourceRendererTestUtil.java
@@ -26,7 +26,7 @@ import io.wcm.caravan.hal.resource.HalResource;
 import io.wcm.caravan.hal.resource.Link;
 import io.wcm.caravan.rhyme.api.common.RequestMetricsCollector;
 import io.wcm.caravan.rhyme.api.resources.LinkableResource;
-import io.wcm.caravan.rhyme.impl.metadata.ResponseMetadataGenerator;
+import io.wcm.caravan.rhyme.impl.metadata.FullMetadataGenerator;
 import io.wcm.caravan.rhyme.impl.reflection.DefaultHalApiTypeSupport;
 import io.wcm.caravan.rhyme.testing.TestState;
 
@@ -39,7 +39,7 @@ public final class AsyncHalResourceRendererTestUtil {
 
   public static HalResource render(Object resourceImplInstance) {
 
-    RequestMetricsCollector metrics = new ResponseMetadataGenerator();
+    RequestMetricsCollector metrics = new FullMetadataGenerator();
     AsyncHalResourceRendererImpl renderer = new AsyncHalResourceRendererImpl(metrics, new DefaultHalApiTypeSupport());
 
     Single<HalResource> rxResource;

--- a/examples/osgi-jaxrs-example-launchpad/src/test/java/io/wcm/caravan/rhyme/osgi/it/tests/HttpErrorResourcesIT.java
+++ b/examples/osgi-jaxrs-example-launchpad/src/test/java/io/wcm/caravan/rhyme/osgi/it/tests/HttpErrorResourcesIT.java
@@ -98,14 +98,14 @@ public class HttpErrorResourcesIT {
   }
 
   @Test
-  public void error_response_should_contain_embedded_metadata() {
+  public void error_response_should_not_contain_embedded_metadata_if_request_param_is_not_set() {
 
     HalApiClientException ex = catchExceptionForRequestWith(defaultParams);
 
     HalResource metadata = ex.getErrorResponse().getBody().getEmbeddedResource("rhyme:metadata");
 
     assertThat(metadata)
-        .isNotNull();
+        .isNull();
   }
 
   @Test

--- a/examples/osgi-jaxrs-example-launchpad/src/test/java/io/wcm/caravan/rhyme/osgi/it/tests/ServerSideErrorResourcesIT.java
+++ b/examples/osgi-jaxrs-example-launchpad/src/test/java/io/wcm/caravan/rhyme/osgi/it/tests/ServerSideErrorResourcesIT.java
@@ -95,14 +95,14 @@ public class ServerSideErrorResourcesIT {
   }
 
   @Test
-  public void error_response_should_contain_embedded_metadata() {
+  public void error_response_should_not_contain_embedded_metadata_because_query_param_is_not_present() {
 
     HalApiClientException ex = catchExceptionForRequestWith(defaultParams);
 
     HalResource metadata = ex.getErrorResponse().getBody().getEmbeddedResource("rhyme:metadata");
 
     assertThat(metadata)
-        .isNotNull();
+        .isNull();
   }
 
   @Test

--- a/integration/aem/src/main/java/io/wcm/caravan/rhyme/aem/impl/HalApiServlet.java
+++ b/integration/aem/src/main/java/io/wcm/caravan/rhyme/aem/impl/HalApiServlet.java
@@ -51,8 +51,6 @@ public class HalApiServlet extends SlingSafeMethodsServlet {
 
   public static final String EXTENSION = "rhyme";
 
-  static final String QUERY_PARAM_EMBED_METADATA = "embedMetadata";
-
   @Reference
   private RhymeResourceRegistry registry;
 
@@ -119,15 +117,7 @@ public class HalApiServlet extends SlingSafeMethodsServlet {
 
     HalResource responseBody = halResponse.getBody();
 
-    if (shouldMetadataBeRemoved(request)) {
-      responseBody.removeEmbedded("rhyme:metadata");
-    }
-
     OBJECT_MAPPER.writeValue(servletResponse.getWriter(), responseBody.getModel());
-  }
-
-  private boolean shouldMetadataBeRemoved(SlingHttpServletRequest request) {
-    return !request.getParameterMap().containsKey(QUERY_PARAM_EMBED_METADATA);
   }
 
 }

--- a/integration/aem/src/main/java/io/wcm/caravan/rhyme/aem/impl/SlingRhymeImpl.java
+++ b/integration/aem/src/main/java/io/wcm/caravan/rhyme/aem/impl/SlingRhymeImpl.java
@@ -26,6 +26,7 @@ import io.wcm.caravan.rhyme.aem.impl.docs.RhymeDocsOsgiBundleSupport;
 import io.wcm.caravan.rhyme.aem.impl.util.PageUtils;
 import io.wcm.caravan.rhyme.api.Rhyme;
 import io.wcm.caravan.rhyme.api.RhymeBuilder;
+import io.wcm.caravan.rhyme.api.common.RequestMetricsCollector;
 import io.wcm.caravan.rhyme.api.common.RequestMetricsStopwatch;
 import io.wcm.caravan.rhyme.api.exceptions.HalApiDeveloperException;
 import io.wcm.caravan.rhyme.api.exceptions.HalApiServerException;
@@ -55,8 +56,14 @@ public class SlingRhymeImpl extends SlingAdaptable implements SlingRhyme {
     // created for different context-resources.
     this.urlHandler = request.adaptTo(UrlHandler.class);
 
-    this.rhyme = RhymeBuilder.withResourceLoader(resourceLoaders.getResourceLoader())
-        .withRhymeDocsSupport(rhymeDocs)
+    RhymeBuilder rhymeBuilder = RhymeBuilder.withResourceLoader(resourceLoaders.getResourceLoader())
+        .withRhymeDocsSupport(rhymeDocs);
+
+    if (request.getParameterMap().containsKey(RequestMetricsCollector.QUERY_PARAM_TOGGLE)) {
+      rhymeBuilder = rhymeBuilder.withEmbeddedMetadata();
+    }
+
+    this.rhyme = rhymeBuilder
         .buildForRequestTo(request.getRequestURL().toString());
   }
 

--- a/integration/aem/src/test/java/io/wcm/caravan/rhyme/aem/impl/HalApiServletTest.java
+++ b/integration/aem/src/test/java/io/wcm/caravan/rhyme/aem/impl/HalApiServletTest.java
@@ -53,6 +53,7 @@ import io.wcm.caravan.rhyme.aem.testing.context.AppAemContext;
 import io.wcm.caravan.rhyme.aem.testing.models.SelectorSlingTestResource;
 import io.wcm.caravan.rhyme.aem.testing.models.TestResourceRegistration;
 import io.wcm.caravan.rhyme.aem.testing.models.UnregisteredSlingTestResource;
+import io.wcm.caravan.rhyme.api.common.RequestMetricsCollector;
 import io.wcm.caravan.rhyme.api.relations.VndErrorRelations;
 import io.wcm.caravan.rhyme.api.resources.LinkableResource;
 import io.wcm.testing.mock.aem.junit5.AemContext;
@@ -204,7 +205,7 @@ public class HalApiServletTest {
 
     Resource resource = context.create().resource(TEST_RESOURCE_PATH);
 
-    context.request().setQueryString(HalApiServlet.QUERY_PARAM_EMBED_METADATA);
+    context.request().setQueryString(RequestMetricsCollector.QUERY_PARAM_TOGGLE);
 
     MockSlingHttpServletResponse response = requestResource(resource, SelectorSlingTestResource.SELECTOR);
 

--- a/integration/osgi-jaxrs/src/main/java/io/wcm/caravan/rhyme/caravan/impl/CaravanRhymeRequestCycleImpl.java
+++ b/integration/osgi-jaxrs/src/main/java/io/wcm/caravan/rhyme/caravan/impl/CaravanRhymeRequestCycleImpl.java
@@ -74,13 +74,20 @@ public class CaravanRhymeRequestCycleImpl implements CaravanRhymeRequestCycle {
 
   static final class CaravanRhymeImpl implements CaravanRhyme {
 
-    private final RequestMetricsCollector metrics = RequestMetricsCollector.create();
+    private final RequestMetricsCollector metrics;
 
     private final CaravanHalApiClient halApiClient;
 
     private final UriInfo requestUri;
 
     CaravanRhymeImpl(CaravanHalApiClient halApiClient, UriInfo requestUri) {
+
+      // only use the full implementation of RequestMetricsCollector (which will will collect and render extensive metadata
+      // into the response) if the request parameter that toggles this behaviour is set
+      this.metrics = requestUri.getQueryParameters().containsKey(RequestMetricsCollector.QUERY_PARAM_TOGGLE)
+          ? RequestMetricsCollector.create()
+          : RequestMetricsCollector.createEssentialCollector();
+
       this.halApiClient = halApiClient;
       this.requestUri = requestUri;
     }

--- a/integration/osgi-jaxrs/src/main/java/io/wcm/caravan/rhyme/jaxrs/impl/JaxRsAsyncHalResponseHandlerImpl.java
+++ b/integration/osgi-jaxrs/src/main/java/io/wcm/caravan/rhyme/jaxrs/impl/JaxRsAsyncHalResponseHandlerImpl.java
@@ -73,7 +73,7 @@ public class JaxRsAsyncHalResponseHandlerImpl implements JaxRsAsyncHalResponseRe
   public void respondWith(LinkableResource resourceImpl, UriInfo uriInfo, AsyncResponse suspended, RequestMetricsCollector metrics) {
 
     try {
-      // create a response renderer all required customizations for OSGI/JAX-RS
+      // create a response renderer with all required customizations for OSGI/JAX-RS
       AsyncHalResponseRenderer renderer = HalResponseRendererBuilder.create()
           .withMetrics(metrics)
           .withExceptionStrategy(exceptionStrategy)


### PR DESCRIPTION
Previously the "rhyme:metadata" resource was always included in the response. With this PR you'll have to explicitly call RhymeBuilder#withEmbeddedMetadata for this.

For the AEM, Spring and OSGI / JAX-RS integrations, this will happen automatically for every request that has a "embedRhymeMetadata" query parameter, so that you can easily toggle this behaviour at runtime for individual requests as required.