### PR TITLE
Introduce RhymeMetadataConfiguration

### DIFF
--- a/core/src/main/java/io/wcm/caravan/rhyme/api/RhymeBuilder.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/api/RhymeBuilder.java
@@ -24,6 +24,7 @@ import org.osgi.annotation.versioning.ProviderType;
 import io.wcm.caravan.rhyme.api.client.HalApiClient;
 import io.wcm.caravan.rhyme.api.common.HalResponse;
 import io.wcm.caravan.rhyme.api.resources.LinkableResource;
+import io.wcm.caravan.rhyme.api.server.RhymeMetadataConfiguration;
 import io.wcm.caravan.rhyme.api.spi.ExceptionStatusAndLoggingStrategy;
 import io.wcm.caravan.rhyme.api.spi.HalApiAnnotationSupport;
 import io.wcm.caravan.rhyme.api.spi.HalApiReturnTypeSupport;
@@ -112,11 +113,12 @@ public interface RhymeBuilder {
   RhymeBuilder withExceptionStrategy(ExceptionStatusAndLoggingStrategy customStrategy);
 
   /**
-   * Enables the capturing of extensive performance and upstream response metadata for this request,
-   * which will be included as an embedded resource in the response.
+   * Configures the capturing of extensive performance and upstream response metadata for this request,
+   * which can be included as an embedded resource in the response.
+   * @param configuration to determine whether metadata should be rendered and included in the current request
    * @return this
    */
-  RhymeBuilder withEmbeddedMetadata();
+  RhymeBuilder withMetadataConfiguration(RhymeMetadataConfiguration configuration);
 
   /**
    * Create the {@link Rhyme} instance to be used to throughout the lifecycle of an incoming request

--- a/core/src/main/java/io/wcm/caravan/rhyme/api/client/HalApiClientBuilder.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/api/client/HalApiClientBuilder.java
@@ -67,8 +67,8 @@ public interface HalApiClientBuilder {
    * If you only want to consume HAL APIs and not use Rhyme to render your responses, you don't need
    * to worry about the {@link RequestMetricsCollector}.
    * </p>
-   * * @param metricsSharedWithRenderer the same instance that will be used to create the
-   * {@link AsyncHalResourceRenderer}
+   * @param metricsSharedWithRenderer the same instance that will be used to create the
+   *          {@link AsyncHalResourceRenderer}
    * @return this
    */
   HalApiClientBuilder withMetrics(RequestMetricsCollector metricsSharedWithRenderer);

--- a/core/src/main/java/io/wcm/caravan/rhyme/api/common/RequestMetricsCollector.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/api/common/RequestMetricsCollector.java
@@ -32,6 +32,7 @@ import io.wcm.caravan.rhyme.api.client.HalApiClientBuilder;
 import io.wcm.caravan.rhyme.api.resources.LinkableResource;
 import io.wcm.caravan.rhyme.api.server.AsyncHalResponseRenderer;
 import io.wcm.caravan.rhyme.api.server.HalResponseRendererBuilder;
+import io.wcm.caravan.rhyme.api.server.RhymeMetadataConfiguration;
 import io.wcm.caravan.rhyme.impl.metadata.FullMetadataGenerator;
 import io.wcm.caravan.rhyme.impl.metadata.MaxAgeOnlyCollector;
 
@@ -42,8 +43,8 @@ import io.wcm.caravan.rhyme.impl.metadata.MaxAgeOnlyCollector;
  * <p>
  * You shouldn't have to interact with this interface directly except for advanced integration or testing scenarios.
  * Usually an instance of this interface is automatically created for each {@link Rhyme} instance, and can choose
- * whether you want to include the embedded metadata in the response by calling
- * {@link RhymeBuilder#withEmbeddedMetadata()}.
+ * whether you want to include the embedded metadata in the response via
+ * {@link RhymeBuilder#withMetadataConfiguration(RhymeMetadataConfiguration)}.
  * </p>
  * <p>
  * If you are not working with {@link RhymeBuilder}, but are integrating {@link HalApiClient} and
@@ -52,6 +53,7 @@ import io.wcm.caravan.rhyme.impl.metadata.MaxAgeOnlyCollector;
  * {@link HalApiClientBuilder#withMetrics(RequestMetricsCollector)}
  * and {@link HalResponseRendererBuilder#withMetrics(RequestMetricsCollector)}.
  * </p>
+ * @see RhymeMetadataConfiguration
  */
 @ProviderType
 public interface RequestMetricsCollector {
@@ -59,8 +61,7 @@ public interface RequestMetricsCollector {
   /**
    * The name of the query parameter that toggles whether the "rhyme:metadata" resource is embedded when rendering
    * resources. This applies only if you are using one of the framework integrations (e.g. Spring, AEM) in default
-   * configuration. To enable the inclusion of the metadata programmatically, call
-   * {@link RhymeBuilder#withEmbeddedMetadata()}.
+   * configuration, where this logic is implemented with a framework specific {@link RhymeMetadataConfiguration}
    */
   public static final String EMBED_RHYME_METADATA = "embedRhymeMetadata";
 
@@ -123,10 +124,10 @@ public interface RequestMetricsCollector {
   /**
    * Create a new instance to collect the full data on upstream requests and measure performance for the current
    * incoming request. When this instance is used with {@link AsyncHalResponseRenderer}, a metadata resource with
-   * insight on performance and upstream requests will be automatically embedded in the response.If you don't need or
+   * insight on performance and upstream requests will be automatically embedded in the response. If you don't need or
    * want this, then use {@link RequestMetricsCollector#createEssentialCollector()} instead
    * @return a new full-featured instance of {@link RequestMetricsCollector}
-   * @see RhymeBuilder#withEmbeddedMetadata()
+   * @see HalApiClientBuilder#withMetrics(RequestMetricsCollector)
    * @see HalResponseRendererBuilder#withMetrics(RequestMetricsCollector)
    */
   static RequestMetricsCollector create() {

--- a/core/src/main/java/io/wcm/caravan/rhyme/api/server/RhymeMetadataConfiguration.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/api/server/RhymeMetadataConfiguration.java
@@ -1,0 +1,44 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2022 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.caravan.rhyme.api.server;
+
+import io.wcm.caravan.rhyme.api.Rhyme;
+import io.wcm.caravan.rhyme.api.RhymeBuilder;
+import io.wcm.caravan.rhyme.api.common.RequestMetricsCollector;
+import io.wcm.caravan.rhyme.api.resources.LinkableResource;
+
+/**
+ * Defines configuration methods to influence if and how {@link Rhyme#renderResponse(LinkableResource)}
+ * adds additional metadata to the response
+ * @see RhymeBuilder#withMetadataConfiguration(RhymeMetadataConfiguration)
+ * @see RequestMetricsCollector
+ */
+public interface RhymeMetadataConfiguration {
+
+  /**
+   * Determines whether an "rhyme:metadata" resource is automatically embedded into the response rendered with
+   * {@link Rhyme#renderResponse(LinkableResource)}
+   * @return true if metadata should be generated and enabled
+   * @see RequestMetricsCollector
+   */
+  default boolean isMetadataGenerationEnabled() {
+    return false;
+  }
+}

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/AbstractRhymeBuilder.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/AbstractRhymeBuilder.java
@@ -35,6 +35,7 @@ import io.wcm.caravan.rhyme.api.common.RequestMetricsCollector;
 import io.wcm.caravan.rhyme.api.exceptions.HalApiDeveloperException;
 import io.wcm.caravan.rhyme.api.server.AsyncHalResponseRenderer;
 import io.wcm.caravan.rhyme.api.server.HalResponseRendererBuilder;
+import io.wcm.caravan.rhyme.api.server.RhymeMetadataConfiguration;
 import io.wcm.caravan.rhyme.api.server.VndErrorResponseRenderer;
 import io.wcm.caravan.rhyme.api.spi.ExceptionStatusAndLoggingStrategy;
 import io.wcm.caravan.rhyme.api.spi.HalApiAnnotationSupport;
@@ -119,9 +120,11 @@ abstract class AbstractRhymeBuilder<BuilderInterface> {
   }
 
   @SuppressWarnings("unchecked")
-  public BuilderInterface withEmbeddedMetadata() {
+  public BuilderInterface withMetadataConfiguration(RhymeMetadataConfiguration configuration) {
 
-    this.metrics = RequestMetricsCollector.create();
+    if (configuration.isMetadataGenerationEnabled()) {
+      this.metrics = RequestMetricsCollector.create();
+    }
     return (BuilderInterface)this;
   }
 

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/AbstractRhymeBuilder.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/AbstractRhymeBuilder.java
@@ -71,6 +71,8 @@ abstract class AbstractRhymeBuilder<BuilderInterface> {
 
   private RhymeDocsSupport rhymeDocsSupport;
 
+  private RhymeMetadataConfiguration metadataConfiguration;
+
   protected boolean wasUsedToBuild;
 
   @SuppressWarnings("unchecked")
@@ -122,9 +124,7 @@ abstract class AbstractRhymeBuilder<BuilderInterface> {
   @SuppressWarnings("unchecked")
   public BuilderInterface withMetadataConfiguration(RhymeMetadataConfiguration configuration) {
 
-    if (configuration.isMetadataGenerationEnabled()) {
-      this.metrics = RequestMetricsCollector.create();
-    }
+    metadataConfiguration = configuration;
     return (BuilderInterface)this;
   }
 
@@ -168,8 +168,19 @@ abstract class AbstractRhymeBuilder<BuilderInterface> {
       resourceLoader = HalResourceLoader.create();
     }
 
+    if (metadataConfiguration == null) {
+      metadataConfiguration = new RhymeMetadataConfiguration() {
+        // use default implementations from interface only
+      };
+    }
+
     if (metrics == null) {
-      metrics = RequestMetricsCollector.createEssentialCollector();
+      if (metadataConfiguration.isMetadataGenerationEnabled()) {
+        metrics = RequestMetricsCollector.create();
+      }
+      else {
+        metrics = RequestMetricsCollector.createEssentialCollector();
+      }
     }
   }
 

--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/RhymeImplTest.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/RhymeImplTest.java
@@ -237,6 +237,18 @@ public class RhymeImplTest {
         .endsWith("- 1x invocation of #createLink");
   }
 
+  @Test
+  public void startStopwatch_should_not_create_metadata_with_defaut_configuration() throws Exception {
+
+    MeasuringTestResource resourceImpl = new MeasuringTestResource(rhyme);
+
+    HalResponse response = rhyme.renderResponse(resourceImpl).blockingGet();
+
+    HalResource metadata = response.getBody().getEmbeddedResource(RHYME_METADATA_RELATION);
+
+    assertThat(metadata).isNull();
+  }
+
   static class MeasuringTestResource implements LinkableTestResource {
 
     private final Rhyme rhyme;

--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/RhymeImplTest.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/RhymeImplTest.java
@@ -44,6 +44,7 @@ import io.wcm.caravan.rhyme.api.common.HalResponse;
 import io.wcm.caravan.rhyme.api.common.RequestMetricsStopwatch;
 import io.wcm.caravan.rhyme.api.exceptions.HalApiClientException;
 import io.wcm.caravan.rhyme.api.exceptions.HalApiServerException;
+import io.wcm.caravan.rhyme.api.server.RhymeMetadataConfiguration;
 import io.wcm.caravan.rhyme.api.server.VndErrorResponseRenderer;
 import io.wcm.caravan.rhyme.impl.renderer.blocking.RenderResourceStateTest.TestResourceWithRequiredState;
 import io.wcm.caravan.rhyme.testing.LinkableTestResource;
@@ -204,7 +205,14 @@ public class RhymeImplTest {
 
     Rhyme rhymeWithMetadata = RhymeBuilder
         .create()
-        .withEmbeddedMetadata()
+        .withMetadataConfiguration(new RhymeMetadataConfiguration() {
+
+          @Override
+          public boolean isMetadataGenerationEnabled() {
+            return true;
+          }
+
+        })
         .buildForRequestTo(INCOMING_REQUEST_URI);
 
     MeasuringTestResource resourceImpl = new MeasuringTestResource(rhymeWithMetadata);

--- a/integration/aem/src/main/java/io/wcm/caravan/rhyme/aem/impl/SlingRhymeImpl.java
+++ b/integration/aem/src/main/java/io/wcm/caravan/rhyme/aem/impl/SlingRhymeImpl.java
@@ -1,5 +1,7 @@
 package io.wcm.caravan.rhyme.aem.impl;
 
+import static io.wcm.caravan.rhyme.api.common.RequestMetricsCollector.EMBED_RHYME_METADATA;
+
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Objects;
@@ -26,10 +28,10 @@ import io.wcm.caravan.rhyme.aem.impl.docs.RhymeDocsOsgiBundleSupport;
 import io.wcm.caravan.rhyme.aem.impl.util.PageUtils;
 import io.wcm.caravan.rhyme.api.Rhyme;
 import io.wcm.caravan.rhyme.api.RhymeBuilder;
-import io.wcm.caravan.rhyme.api.common.RequestMetricsCollector;
 import io.wcm.caravan.rhyme.api.common.RequestMetricsStopwatch;
 import io.wcm.caravan.rhyme.api.exceptions.HalApiDeveloperException;
 import io.wcm.caravan.rhyme.api.exceptions.HalApiServerException;
+import io.wcm.caravan.rhyme.api.server.RhymeMetadataConfiguration;
 import io.wcm.handler.url.UrlHandler;
 
 @Model(adaptables = SlingHttpServletRequest.class, adapters = { SlingRhyme.class, SlingRhymeImpl.class })
@@ -56,14 +58,15 @@ public class SlingRhymeImpl extends SlingAdaptable implements SlingRhyme {
     // created for different context-resources.
     this.urlHandler = request.adaptTo(UrlHandler.class);
 
-    RhymeBuilder rhymeBuilder = RhymeBuilder.withResourceLoader(resourceLoaders.getResourceLoader())
-        .withRhymeDocsSupport(rhymeDocs);
+    this.rhyme = RhymeBuilder.withResourceLoader(resourceLoaders.getResourceLoader())
+        .withRhymeDocsSupport(rhymeDocs)
+        .withMetadataConfiguration(new RhymeMetadataConfiguration() {
 
-    if (request.getParameterMap().containsKey(RequestMetricsCollector.EMBED_RHYME_METADATA)) {
-      rhymeBuilder = rhymeBuilder.withEmbeddedMetadata();
-    }
-
-    this.rhyme = rhymeBuilder
+          @Override
+          public boolean isMetadataGenerationEnabled() {
+            return request.getParameterMap().containsKey(EMBED_RHYME_METADATA);
+          }
+        })
         .buildForRequestTo(request.getRequestURL().toString());
   }
 


### PR DESCRIPTION
RhymeBuilder#withEmbeddedMetadata is replaced with RhymeBuilder#withMetadataConfiguration to allow additional configuration options in the future 