### PR TITLE
Remove jackson-datatype-guava dependency

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -92,11 +92,6 @@
       <artifactId>jackson-databind</artifactId>
       <scope>compile</scope>
     </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-guava</artifactId>
-      <scope>compile</scope>
-    </dependency>
 
     <!-- RxJava -->
     <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -46,8 +46,9 @@
   <properties>
     <site.url.module.prefix>rhyme/core</site.url.module.prefix>
   </properties>
-  
+
   <dependencies>
+
     <!-- wcm.io -->
     <dependency>
       <groupId>io.wcm.caravan</groupId>
@@ -75,7 +76,17 @@
       <scope>provided</scope>
     </dependency>
 
-    <!-- Jackson -->
+   <!-- Jackson -->
+   <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <scope>compile</scope>
+   </dependency>
+   <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <scope>compile</scope>
+   </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>

--- a/core/src/main/java/io/wcm/caravan/rhyme/api/RhymeBuilder.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/api/RhymeBuilder.java
@@ -123,7 +123,9 @@ public interface RhymeBuilder {
   RhymeBuilder withMetadataConfiguration(RhymeMetadataConfiguration configuration);
 
   /**
-   * Replace the default Jackson {@link ObjectMapper} used for JSON (de)serialization with a customized instance
+   * Replace the default Jackson {@link ObjectMapper} used for JSON (de)serialization with a customized instance.
+   * Note that this object mapper is only used when converting Java to JSON objects (and vice versa). It's not
+   * used when the raw JSON response from an upstream service is parsed.
    * @param objectMapper a configured {@link ObjectMapper} instance (which can be a single shared instance)
    * @return this
    */

--- a/core/src/main/java/io/wcm/caravan/rhyme/api/RhymeBuilder.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/api/RhymeBuilder.java
@@ -21,6 +21,8 @@ package io.wcm.caravan.rhyme.api;
 
 import org.osgi.annotation.versioning.ProviderType;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import io.wcm.caravan.rhyme.api.client.HalApiClient;
 import io.wcm.caravan.rhyme.api.common.HalResponse;
 import io.wcm.caravan.rhyme.api.resources.LinkableResource;
@@ -119,6 +121,13 @@ public interface RhymeBuilder {
    * @return this
    */
   RhymeBuilder withMetadataConfiguration(RhymeMetadataConfiguration configuration);
+
+  /**
+   * Replace the default Jackson {@link ObjectMapper} used for JSON (de)serialization with a customized instance
+   * @param objectMapper a configured {@link ObjectMapper} instance (which can be a single shared instance)
+   * @return this
+   */
+  RhymeBuilder withObjectMapper(ObjectMapper objectMapper);
 
   /**
    * Create the {@link Rhyme} instance to be used to throughout the lifecycle of an incoming request

--- a/core/src/main/java/io/wcm/caravan/rhyme/api/client/HalApiClientBuilder.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/api/client/HalApiClientBuilder.java
@@ -92,7 +92,9 @@ public interface HalApiClientBuilder {
   HalApiClientBuilder withAnnotationTypeSupport(HalApiAnnotationSupport additionalTypeSupport);
 
   /**
-   * Replace the default Jackson {@link ObjectMapper} used for JSON deserialization with a customized instance
+   * Replace the default Jackson {@link ObjectMapper} used for JSON deserialization with a customized instance.
+   * Note that this object mapper is only used when converting JSON to Java Objects. It's not
+   * used when the raw JSON response from an upstream service is parsed.
    * @param objectMapper a configured {@link ObjectMapper} instance (which can be a single shared instance)
    * @return this
    */

--- a/core/src/main/java/io/wcm/caravan/rhyme/api/client/HalApiClientBuilder.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/api/client/HalApiClientBuilder.java
@@ -21,6 +21,8 @@ package io.wcm.caravan.rhyme.api.client;
 
 import org.osgi.annotation.versioning.ProviderType;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import io.wcm.caravan.rhyme.api.Rhyme;
 import io.wcm.caravan.rhyme.api.RhymeBuilder;
 import io.wcm.caravan.rhyme.api.common.RequestMetricsCollector;
@@ -88,6 +90,13 @@ public interface HalApiClientBuilder {
    * @return this
    */
   HalApiClientBuilder withAnnotationTypeSupport(HalApiAnnotationSupport additionalTypeSupport);
+
+  /**
+   * Replace the default Jackson {@link ObjectMapper} used for JSON deserialization with a customized instance
+   * @param objectMapper a configured {@link ObjectMapper} instance (which can be a single shared instance)
+   * @return this
+   */
+  HalApiClientBuilder withObjectMapper(ObjectMapper objectMapper);
 
   /**
    * @return the new {@link HalApiClient} instance

--- a/core/src/main/java/io/wcm/caravan/rhyme/api/server/HalResponseRendererBuilder.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/api/server/HalResponseRendererBuilder.java
@@ -21,6 +21,8 @@ package io.wcm.caravan.rhyme.api.server;
 
 import org.osgi.annotation.versioning.ProviderType;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import io.wcm.caravan.rhyme.api.Rhyme;
 import io.wcm.caravan.rhyme.api.RhymeBuilder;
 import io.wcm.caravan.rhyme.api.client.HalApiClient;
@@ -90,6 +92,13 @@ public interface HalResponseRendererBuilder {
    * @return this
    */
   HalResponseRendererBuilder withExceptionStrategy(ExceptionStatusAndLoggingStrategy customStrategy);
+
+  /**
+   * Replace the default Jackson {@link ObjectMapper} used for JSON serialization with a customized instance
+   * @param objectMapper a configured {@link ObjectMapper} instance (which can be a single shared instance)
+   * @return this
+   */
+  HalResponseRendererBuilder withObjectMapper(ObjectMapper objectMapper);
 
   /**
    * @return the new {@link AsyncHalResponseRenderer} instance

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/AbstractRhymeBuilder.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/AbstractRhymeBuilder.java
@@ -209,7 +209,7 @@ abstract class AbstractRhymeBuilder<BuilderInterface> {
 
     HalApiTypeSupport typeSupport = getEffectiveTypeSupport();
 
-    AsyncHalResourceRenderer resourceRenderer = new AsyncHalResourceRendererImpl(metrics, typeSupport);
+    AsyncHalResourceRenderer resourceRenderer = new AsyncHalResourceRendererImpl(metrics, typeSupport, objectMapper);
 
     ExceptionStatusAndLoggingStrategy exceptionStrategy = getEffectiveExceptionStrategy();
 

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/client/HalApiClientImpl.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/client/HalApiClientImpl.java
@@ -19,6 +19,7 @@
  */
 package io.wcm.caravan.rhyme.impl.client;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
 
 import io.wcm.caravan.rhyme.api.client.HalApiClient;
@@ -43,13 +44,14 @@ public class HalApiClientImpl implements HalApiClient {
    * @param metrics an instance of {@link RequestMetricsCollector} to collect performance relevant data for the current
    *          incoming request
    * @param typeSupport the strategy to detect HAL API annotations and perform type conversions
+   * @param objectMapper the Jackson {@link ObjectMapper} to use for all JSON deserialisation
    */
-  public HalApiClientImpl(HalResourceLoader resourceLoader, RequestMetricsCollector metrics, HalApiTypeSupport typeSupport) {
+  public HalApiClientImpl(HalResourceLoader resourceLoader, RequestMetricsCollector metrics, HalApiTypeSupport typeSupport, ObjectMapper objectMapper) {
 
     Preconditions.checkNotNull(resourceLoader, "A " + HalResourceLoader.class.getName() + " instance must be provided");
     HalResourceLoaderWrapper wrapper = new HalResourceLoaderWrapper(resourceLoader, metrics);
 
-    factory = new HalApiClientProxyFactory(wrapper, metrics, typeSupport);
+    factory = new HalApiClientProxyFactory(wrapper, metrics, typeSupport, objectMapper);
 
     this.typeSupport = typeSupport;
   }

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/HalApiClientProxyFactory.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/HalApiClientProxyFactory.java
@@ -26,6 +26,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.util.concurrent.UncheckedExecutionException;
@@ -56,17 +57,21 @@ public final class HalApiClientProxyFactory {
   private final HalResourceLoader resourceLoader;
   private final RequestMetricsCollector metrics;
   private final HalApiTypeSupport typeSupport;
+  private final ObjectMapper objectMapper;
 
   /**
    * @param resourceLoader used to load/cache HAL+JSON resources
    * @param metrics an instance of {@link RequestMetricsCollector} to collect performance relevant data for the current
    *          incoming request
    * @param typeSupport the strategy to detect HAL API annotations and perform type conversions
+   * @param objectMapper the Jackson {@link ObjectMapper} to use for all JSON deserialisation
    */
-  public HalApiClientProxyFactory(HalResourceLoader resourceLoader, RequestMetricsCollector metrics, HalApiTypeSupport typeSupport) {
+  public HalApiClientProxyFactory(HalResourceLoader resourceLoader, RequestMetricsCollector metrics, HalApiTypeSupport typeSupport, ObjectMapper objectMapper) {
     this.metrics = metrics;
     this.resourceLoader = resourceLoader;
     this.typeSupport = typeSupport;
+    this.objectMapper = objectMapper;
+
   }
 
   public <T> T createProxyFromUrl(Class<T> relatedResourceType, String url) {
@@ -154,7 +159,7 @@ public final class HalApiClientProxyFactory {
       Class[] interfaces = getInterfacesToImplement(relatedResourceType);
 
       // the main logic of the proxy is implemented in this InvocationHandler
-      HalApiInvocationHandler invocationHandler = new HalApiInvocationHandler(rxHal, relatedResourceType, linkToResource, this, metrics, typeSupport);
+      HalApiInvocationHandler invocationHandler = new HalApiInvocationHandler(rxHal, relatedResourceType, linkToResource, this, metrics, typeSupport, objectMapper);
 
       @SuppressWarnings("unchecked")
       T proxy = (T)Proxy.newProxyInstance(relatedResourceType.getClassLoader(), interfaces, invocationHandler);

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/ResourcePropertyHandler.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/ResourcePropertyHandler.java
@@ -19,9 +19,8 @@
  */
 package io.wcm.caravan.rhyme.impl.client.proxy;
 
-import static io.wcm.caravan.rhyme.impl.client.proxy.ResourceStateHandler.OBJECT_MAPPER;
-
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.reactivex.rxjava3.core.Observable;
 import io.wcm.caravan.hal.resource.HalResource;
@@ -34,10 +33,12 @@ class ResourcePropertyHandler {
 
   private final HalResource contextResource;
   private final HalApiTypeSupport typeSupport;
+  private final ObjectMapper objectMapper;
 
-  ResourcePropertyHandler(HalResource contextResource, HalApiTypeSupport typeSupport) {
+  ResourcePropertyHandler(HalResource contextResource, HalApiTypeSupport typeSupport, ObjectMapper objectMapper) {
     this.contextResource = contextResource;
     this.typeSupport = typeSupport;
+    this.objectMapper = objectMapper;
   }
 
   Observable<Object> handleMethodInvocation(HalApiMethodInvocation invocation) {
@@ -77,8 +78,7 @@ class ResourcePropertyHandler {
   }
 
   Object convertToJavaObject(HalApiMethodInvocation invocation, JsonNode jsonNode) {
-    Object propertyValue = OBJECT_MAPPER.convertValue(jsonNode, invocation.getEmissionType());
-    return propertyValue;
+    return objectMapper.convertValue(jsonNode, invocation.getEmissionType());
   }
 
   Observable<Object> errorObservable(String msg) {

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/ResourceStateHandler.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/ResourceStateHandler.java
@@ -24,7 +24,6 @@ import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.guava.GuavaModule;
 
 import io.reactivex.rxjava3.core.Maybe;
 import io.wcm.caravan.hal.resource.HalResource;
@@ -33,7 +32,6 @@ import io.wcm.caravan.rhyme.impl.reflection.HalApiTypeSupport;
 class ResourceStateHandler {
 
   static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
-      .registerModule(new GuavaModule()) // allows de-serialization of Guava collections
       .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 
   private static final Logger log = LoggerFactory.getLogger(HalApiInvocationHandler.class);

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/ResourceStateHandler.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/ResourceStateHandler.java
@@ -22,7 +22,6 @@ package io.wcm.caravan.rhyme.impl.client.proxy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.reactivex.rxjava3.core.Maybe;
@@ -31,17 +30,16 @@ import io.wcm.caravan.rhyme.impl.reflection.HalApiTypeSupport;
 
 class ResourceStateHandler {
 
-  static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
-      .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
-
   private static final Logger log = LoggerFactory.getLogger(HalApiInvocationHandler.class);
 
   private final HalResource contextResource;
   private final HalApiTypeSupport typeSupport;
+  private final ObjectMapper objectMapper;
 
-  ResourceStateHandler(HalResource contextResource, HalApiTypeSupport typeSupport) {
+  ResourceStateHandler(HalResource contextResource, HalApiTypeSupport typeSupport, ObjectMapper objectMapper) {
     this.contextResource = contextResource;
     this.typeSupport = typeSupport;
+    this.objectMapper = objectMapper;
   }
 
   Maybe<Object> handleMethodInvocation(HalApiMethodInvocation invocation) {
@@ -65,7 +63,7 @@ class ResourceStateHandler {
 
   private Object convertResourceProperties(Class<?> resourcePropertiesType) {
 
-    return OBJECT_MAPPER.convertValue(contextResource.getModel(), resourcePropertiesType);
+    return objectMapper.convertValue(contextResource.getModel(), resourcePropertiesType);
   }
 
 }

--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/RhymeBuilderImplTest.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/RhymeBuilderImplTest.java
@@ -41,10 +41,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeType;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Ordering;
 import com.google.common.collect.Sets;
 
+import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Observable;
 import io.wcm.caravan.hal.resource.HalResource;
 import io.wcm.caravan.hal.resource.Link;
@@ -511,4 +515,53 @@ public class RhymeBuilderImplTest {
   }
 
 
+  @Test
+  public void should_use_default_object_mapper_which_serialises_null_fields() {
+
+    LinkableTestResource resourceImpl = new ResourceWithNullStateFields();
+
+    Rhyme builder = RhymeBuilder.create().buildForRequestTo("/foo");
+
+    HalResource hal = builder.renderResponse(resourceImpl).blockingGet().getBody();
+
+    assertThat(hal.getModel().path("string").getNodeType())
+        .isEqualTo(JsonNodeType.NULL);
+
+    assertThat(hal.getModel().path("number").getNodeType())
+        .isEqualTo(JsonNodeType.NULL);
+  }
+
+  @Test
+  public void should_use_custom_object_mapper_which_ignores_null_fields() {
+
+    ObjectMapper customMapper = new ObjectMapper()
+        .setSerializationInclusion(Include.NON_NULL);
+
+    LinkableTestResource resourceImpl = new ResourceWithNullStateFields();
+
+    Rhyme builder = RhymeBuilder.create()
+        .withObjectMapper(customMapper)
+        .buildForRequestTo("/foo");
+
+    HalResource hal = builder.renderResponse(resourceImpl).blockingGet().getBody();
+
+    assertThat(hal.getModel().path("string").getNodeType())
+        .isEqualTo(JsonNodeType.MISSING);
+
+    assertThat(hal.getModel().path("number").getNodeType())
+        .isEqualTo(JsonNodeType.MISSING);
+  }
+
+  private static final class ResourceWithNullStateFields implements LinkableTestResource {
+
+    @Override
+    public Maybe<TestState> getState() {
+      return Maybe.just(new TestState());
+    }
+
+    @Override
+    public Link createLink() {
+      return new Link("/foo");
+    }
+  }
 }

--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/reflection/CompositeHalApiTypeSupportTest.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/reflection/CompositeHalApiTypeSupportTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 
 import io.reactivex.rxjava3.core.Observable;
@@ -53,6 +54,8 @@ import io.wcm.caravan.rhyme.testing.resources.TestResource;
 
 @ExtendWith(MockitoExtension.class)
 public class CompositeHalApiTypeSupportTest {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   private final RequestMetricsCollector metrics = RequestMetricsCollector.create();
 
@@ -120,7 +123,7 @@ public class CompositeHalApiTypeSupportTest {
 
     HalApiTypeSupport typeSupport = DefaultHalApiTypeSupport.extendWith(null, mockReturnTypeSupport);
 
-    AsyncHalResourceRendererImpl renderer = new AsyncHalResourceRendererImpl(metrics, typeSupport);
+    AsyncHalResourceRendererImpl renderer = new AsyncHalResourceRendererImpl(metrics, typeSupport, OBJECT_MAPPER);
 
     assertThatMockReturnTypeSupportIsEffective(renderer.getTypeSupport());
   }
@@ -130,7 +133,7 @@ public class CompositeHalApiTypeSupportTest {
 
     HalApiTypeSupport typeSupport = DefaultHalApiTypeSupport.extendWith(mockAnnotationSupport, null);
 
-    AsyncHalResourceRendererImpl renderer = new AsyncHalResourceRendererImpl(metrics, typeSupport);
+    AsyncHalResourceRendererImpl renderer = new AsyncHalResourceRendererImpl(metrics, typeSupport, OBJECT_MAPPER);
 
     assertThatMockAnnotationSupportIsEffective(renderer.getTypeSupport());
   }

--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/renderer/AsyncHalResourceRendererTestUtil.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/renderer/AsyncHalResourceRendererTestUtil.java
@@ -21,6 +21,8 @@ package io.wcm.caravan.rhyme.impl.renderer;
 
 import org.apache.commons.lang3.RandomUtils;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import io.reactivex.rxjava3.core.Single;
 import io.wcm.caravan.hal.resource.HalResource;
 import io.wcm.caravan.hal.resource.Link;
@@ -40,7 +42,7 @@ public final class AsyncHalResourceRendererTestUtil {
   public static HalResource render(Object resourceImplInstance) {
 
     RequestMetricsCollector metrics = new FullMetadataGenerator();
-    AsyncHalResourceRendererImpl renderer = new AsyncHalResourceRendererImpl(metrics, new DefaultHalApiTypeSupport());
+    AsyncHalResourceRendererImpl renderer = new AsyncHalResourceRendererImpl(metrics, new DefaultHalApiTypeSupport(), new ObjectMapper());
 
     Single<HalResource> rxResource;
     if (resourceImplInstance instanceof LinkableResource) {

--- a/examples/osgi-jaxrs-example-launchpad/src/main/provisioning/integration-test.txt
+++ b/examples/osgi-jaxrs-example-launchpad/src/main/provisioning/integration-test.txt
@@ -11,7 +11,6 @@
   com.fasterxml.jackson.core/jackson-core
   com.fasterxml.jackson.core/jackson-annotations
   com.fasterxml.jackson.core/jackson-databind
-  com.fasterxml.jackson.datatype/jackson-datatype-guava
   commons-beanutils/commons-beanutils
   javax.annotation/javax.annotation-api
   org.apache.commons/commons-lang3/3.3.2

--- a/tooling/parent/pom.xml
+++ b/tooling/parent/pom.xml
@@ -71,11 +71,6 @@
         <artifactId>jackson-databind</artifactId>
         <version>2.11.4</version>
       </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.datatype</groupId>
-        <artifactId>jackson-datatype-guava</artifactId>
-        <version>2.11.4</version>
-      </dependency>
       <!-- RxJava 1 -->
       <dependency>
         <groupId>io.reactivex</groupId>

--- a/tooling/parent/pom.xml
+++ b/tooling/parent/pom.xml
@@ -55,12 +55,26 @@
 
   <dependencyManagement>
     <dependencies>
-
       <!-- Jackson -->
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-annotations</artifactId>
+        <version>2.11.4</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-core</artifactId>
+        <version>2.11.4</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>2.11.4</version>
+      </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-guava</artifactId>
-        <version>2.5.3</version>
+        <version>2.11.4</version>
       </dependency>
       <!-- RxJava 1 -->
       <dependency>


### PR DESCRIPTION
jackson-datatype-guava  was only used to configure a ObjectMapper that allows the HalApiClient to deserialise
classes using Guava types.

This dependency was removed, because it requires specific guava versions to be on the classpath. Now that this dependency is removed, it was possible to update the jackson version to 2.11.4 without running into issues
with bundles not loading in the OSGI launchpad's (which require an outdated guava version).

As an alternative, it's now possible to provide a custom ObjectMapper used for all JSON to Java conversions using the withObjectMapper method in the RyhmeBuilder, HalApiClientBuilder and HalResponseRendererBuilder classes