### PR TITLE
Allow methods annotated with Related to return Link instances directly

### DIFF
--- a/api-interfaces/src/main/java/io/wcm/caravan/rhyme/api/annotations/Related.java
+++ b/api-interfaces/src/main/java/io/wcm/caravan/rhyme/api/annotations/Related.java
@@ -27,8 +27,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import io.wcm.caravan.hal.resource.Link;
 import io.wcm.caravan.rhyme.api.relations.StandardRelations;
-import io.wcm.caravan.rhyme.api.resources.LinkableResource;
 
 /**
  * Used to declare methods which defines a link relation and the expected type for linked or embedded resources.
@@ -39,8 +39,9 @@ import io.wcm.caravan.rhyme.api.resources.LinkableResource;
  * or one of the supported reactive types (e.g. Single, Maybe, Observable).
  * </p>
  * <p>
- * You can also represent links to other non-HAL resources (e.g. HTML, text or binary) by using {@link LinkableResource}
- * as return type.
+ * You can also represent links to other non-HAL resources (e.g. HTML, text or binary) by using {@link Link}
+ * as return type. Again this can be wrapped as appropriate (e.g. a {@link Stream} of {@link Link}s for multiple
+ * external links.
  * </p>
  * <p>
  * Methods with this annotation can have parameters with {@link TemplateVariable} or

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/HalApiClientProxyFactory.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/HalApiClientProxyFactory.java
@@ -41,10 +41,8 @@ import io.wcm.caravan.rhyme.api.common.HalResponse;
 import io.wcm.caravan.rhyme.api.common.RequestMetricsCollector;
 import io.wcm.caravan.rhyme.api.common.RequestMetricsStopwatch;
 import io.wcm.caravan.rhyme.api.exceptions.HalApiDeveloperException;
-import io.wcm.caravan.rhyme.api.resources.LinkableResource;
 import io.wcm.caravan.rhyme.api.spi.HalResourceLoader;
 import io.wcm.caravan.rhyme.impl.metadata.EmissionStopwatch;
-import io.wcm.caravan.rhyme.impl.reflection.HalApiReflectionUtils;
 import io.wcm.caravan.rhyme.impl.reflection.HalApiTypeSupport;
 
 /**
@@ -154,12 +152,6 @@ public final class HalApiClientProxyFactory {
 
       // check that the given class is indeed a HAL api interface
       if (!isHalApiInterface(relatedResourceType, typeSupport)) {
-
-        // if not then it may be a method that uses LinkableResource as return type
-        // in that case, we can create a full implementation based on the link
-        if (HalApiReflectionUtils.isPlainLinkableResource(relatedResourceType)) {
-          return createPlainLinkableResource(linkToResource);
-        }
         throw new HalApiDeveloperException(
             "The given resource interface " + relatedResourceType.getName() + " does not have a @" + HalApiInterface.class.getSimpleName() + " annotation.");
       }
@@ -174,20 +166,6 @@ public final class HalApiClientProxyFactory {
 
       return proxy;
     }
-  }
-
-  private <T> T createPlainLinkableResource(Link linkToResource) {
-
-    @SuppressWarnings("unchecked")
-    T resourceImpl = (T)new LinkableResource() {
-
-      @Override
-      public Link createLink() {
-        return linkToResource;
-      }
-    };
-
-    return resourceImpl;
   }
 
   private <T> Class[] getInterfacesToImplement(Class<T> relatedResourceType) {

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/RelatedResourceHandler.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/RelatedResourceHandler.java
@@ -62,7 +62,7 @@ class RelatedResourceHandler {
     Class<?> relatedResourceType = invocation.getEmissionType();
 
     if (!isHalApiInterface(relatedResourceType, annotationSupport)
-        && !HalApiReflectionUtils.isPlainLinkableResource(relatedResourceType)) {
+        && !HalApiReflectionUtils.isPlainLink(relatedResourceType)) {
       throw new HalApiDeveloperException("The method " + invocation + " has an invalid emission type " + relatedResourceType.getName() +
           " which does not have a @" + HalApiInterface.class.getSimpleName() + " annotation.");
     }
@@ -175,7 +175,14 @@ class RelatedResourceHandler {
         // if the link is templated then expand it with the method parameters
         .map(link -> link.isTemplated() ? expandLinkTemplates(link, parameters) : link)
         // then create a new proxy
-        .map(link -> proxyFactory.createProxyFromLink(relatedResourceType, link));
+        .map(link -> {
+
+          if (Link.class.equals(relatedResourceType)) {
+            return link;
+          }
+
+          return proxyFactory.createProxyFromLink(relatedResourceType, link);
+        });
   }
 
   private static Link expandLinkTemplates(Link link, Map<String, Object> parameters) {

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/RelatedResourceHandler.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/RelatedResourceHandler.java
@@ -174,13 +174,14 @@ class RelatedResourceHandler {
     return Observable.fromIterable(links)
         // if the link is templated then expand it with the method parameters
         .map(link -> link.isTemplated() ? expandLinkTemplates(link, parameters) : link)
-        // then create a new proxy
         .map(link -> {
 
+          // if the method returns a link, then there is no need for a proxy, but we can return it directly
           if (Link.class.equals(relatedResourceType)) {
             return link;
           }
 
+          // otherwise create a new proxy implementing the HalApiInterface of the link target
           return proxyFactory.createProxyFromLink(relatedResourceType, link);
         });
   }

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/RelatedResourceHandler.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/RelatedResourceHandler.java
@@ -39,6 +39,7 @@ import io.wcm.caravan.hal.resource.Link;
 import io.wcm.caravan.rhyme.api.annotations.HalApiInterface;
 import io.wcm.caravan.rhyme.api.exceptions.HalApiDeveloperException;
 import io.wcm.caravan.rhyme.api.spi.HalApiAnnotationSupport;
+import io.wcm.caravan.rhyme.impl.reflection.HalApiReflectionUtils;
 
 class RelatedResourceHandler {
 
@@ -60,7 +61,8 @@ class RelatedResourceHandler {
     String relation = invocation.getRelation();
     Class<?> relatedResourceType = invocation.getEmissionType();
 
-    if (!isHalApiInterface(relatedResourceType, annotationSupport)) {
+    if (!isHalApiInterface(relatedResourceType, annotationSupport)
+        && !HalApiReflectionUtils.isPlainLinkableResource(relatedResourceType)) {
       throw new HalApiDeveloperException("The method " + invocation + " has an invalid emission type " + relatedResourceType.getName() +
           " which does not have a @" + HalApiInterface.class.getSimpleName() + " annotation.");
     }

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/reflection/HalApiReflectionUtils.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/reflection/HalApiReflectionUtils.java
@@ -64,6 +64,24 @@ public final class HalApiReflectionUtils {
         .collectFromClassAndAllSuperClasses(clazz);
   }
 
+  /**
+   * @param clazz the type to check
+   * @return true if the class is {@link LinkableResource} or an interface extending it
+   */
+  public static boolean isPlainLinkableResource(Class clazz) {
+
+    if (!clazz.isInterface()) {
+      return false;
+    }
+
+    if (!LinkableResource.class.isAssignableFrom(clazz)) {
+      return false;
+    }
+
+    return collectInterfaces(clazz).stream()
+        .allMatch(interfaze -> LinkableResource.class.isAssignableFrom(interfaze));
+  }
+
   private static final class InterfaceCollector {
 
     private final Set<Class<?>> collected = new LinkedHashSet<>();

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/reflection/HalApiReflectionUtils.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/reflection/HalApiReflectionUtils.java
@@ -66,20 +66,11 @@ public final class HalApiReflectionUtils {
 
   /**
    * @param clazz the type to check
-   * @return true if the class is {@link LinkableResource} or an interface extending it
+   * @return true if the class is a {@link Link}
    */
-  public static boolean isPlainLinkableResource(Class clazz) {
+  public static boolean isPlainLink(Class clazz) {
 
-    if (!clazz.isInterface()) {
-      return false;
-    }
-
-    if (!LinkableResource.class.isAssignableFrom(clazz)) {
-      return false;
-    }
-
-    return collectInterfaces(clazz).stream()
-        .allMatch(interfaze -> LinkableResource.class.isAssignableFrom(interfaze));
+    return Link.class.equals(clazz);
   }
 
   private static final class InterfaceCollector {

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/renderer/RelatedResourcesRendererImpl.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/renderer/RelatedResourcesRendererImpl.java
@@ -133,7 +133,8 @@ final class RelatedResourcesRendererImpl {
     // get the emitted result resource type from the method signature
     Class<?> relatedResourceInterface = RxJavaReflectionUtils.getObservableEmissionType(method, typeSupport);
 
-    if (!HalApiReflectionUtils.isHalApiInterface(relatedResourceInterface, typeSupport) && !LinkableResource.class.equals(relatedResourceInterface)) {
+    if (!HalApiReflectionUtils.isHalApiInterface(relatedResourceInterface, typeSupport)
+        && !HalApiReflectionUtils.isPlainLinkableResource(relatedResourceInterface)) {
 
       String returnTypeDesc = getReturnTypeDescription(method, relatedResourceInterface);
 

--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/client/RelatedResourceTest.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/client/RelatedResourceTest.java
@@ -39,6 +39,7 @@ import io.wcm.caravan.rhyme.api.annotations.HalApiInterface;
 import io.wcm.caravan.rhyme.api.annotations.Related;
 import io.wcm.caravan.rhyme.api.annotations.ResourceState;
 import io.wcm.caravan.rhyme.api.exceptions.HalApiDeveloperException;
+import io.wcm.caravan.rhyme.api.resources.LinkableResource;
 import io.wcm.caravan.rhyme.impl.client.ClientTestSupport.ResourceTreeClientTestSupport;
 import io.wcm.caravan.rhyme.impl.client.ResourceStateTest.ResourceWithSingleState;
 import io.wcm.caravan.rhyme.testing.TestState;
@@ -326,6 +327,24 @@ public class RelatedResourceTest {
 
     @Related(SECTION)
     Single<TestState> notAnInterface();
+  }
+
+  @Test
+  public void related_resource_method_can_return_linkable_resource() throws Exception {
+
+    TestResource linkedItem = entryPoint.createLinked(ITEM);
+
+    LinkableResource item = client.createProxy(ResourceWithLinkableRelated.class).getItem().blockingGet();
+
+    assertThat(item.createLink().getHref())
+        .isEqualTo(linkedItem.getUrl());
+  }
+
+  @HalApiInterface
+  interface ResourceWithLinkableRelated {
+
+    @Related(ITEM)
+    Single<LinkableResource> getItem();
   }
 
   @Test

--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/client/RelatedResourceTest.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/client/RelatedResourceTest.java
@@ -35,11 +35,11 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.core.Single;
+import io.wcm.caravan.hal.resource.Link;
 import io.wcm.caravan.rhyme.api.annotations.HalApiInterface;
 import io.wcm.caravan.rhyme.api.annotations.Related;
 import io.wcm.caravan.rhyme.api.annotations.ResourceState;
 import io.wcm.caravan.rhyme.api.exceptions.HalApiDeveloperException;
-import io.wcm.caravan.rhyme.api.resources.LinkableResource;
 import io.wcm.caravan.rhyme.impl.client.ClientTestSupport.ResourceTreeClientTestSupport;
 import io.wcm.caravan.rhyme.impl.client.ResourceStateTest.ResourceWithSingleState;
 import io.wcm.caravan.rhyme.testing.TestState;
@@ -330,21 +330,21 @@ public class RelatedResourceTest {
   }
 
   @Test
-  public void related_resource_method_can_return_linkable_resource() throws Exception {
+  public void related_resource_method_can_return_links_directly() throws Exception {
 
     TestResource linkedItem = entryPoint.createLinked(ITEM);
 
-    LinkableResource item = client.createProxy(ResourceWithLinkableRelated.class).getItem().blockingGet();
+    Link link = client.createProxy(ResourceWithLinkReturnType.class).getItem().blockingGet();
 
-    assertThat(item.createLink().getHref())
+    assertThat(link.getHref())
         .isEqualTo(linkedItem.getUrl());
   }
 
   @HalApiInterface
-  interface ResourceWithLinkableRelated {
+  interface ResourceWithLinkReturnType {
 
     @Related(ITEM)
-    Single<LinkableResource> getItem();
+    Single<Link> getItem();
   }
 
   @Test

--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/renderer/AsyncHalResourceRendererTestUtil.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/renderer/AsyncHalResourceRendererTestUtil.java
@@ -55,17 +55,11 @@ public final class AsyncHalResourceRendererTestUtil {
     return rxResource.toObservable().blockingFirst();
   }
 
-  static Single<LinkableResource> createSingleExternalLinkedResource(Link link) {
-    return Single.just(new LinkableResource() {
-
-      @Override
-      public Link createLink() {
-        return link;
-      }
-    });
+  static Single<Link> createSingleExternalLinkedResource(Link link) {
+    return Single.just(link);
   }
 
-  static Single<LinkableResource> createSingleExternalLinkedResource(String uri) {
+  static Single<Link> createSingleExternalLinkedResource(String uri) {
     return createSingleExternalLinkedResource(new Link(uri));
   }
 

--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/renderer/RenderLinkedResourceTest.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/renderer/RenderLinkedResourceTest.java
@@ -40,7 +40,6 @@ import io.wcm.caravan.rhyme.api.annotations.HalApiInterface;
 import io.wcm.caravan.rhyme.api.annotations.Related;
 import io.wcm.caravan.rhyme.api.annotations.TemplateVariable;
 import io.wcm.caravan.rhyme.api.exceptions.HalApiDeveloperException;
-import io.wcm.caravan.rhyme.api.resources.LinkableResource;
 import io.wcm.caravan.rhyme.testing.LinkableTestResource;
 import io.wcm.caravan.rhyme.testing.TestResource;
 
@@ -267,7 +266,7 @@ public class RenderLinkedResourceTest {
   public interface TestResourceWithSingleExternalLink {
 
     @Related(LINKED)
-    Single<LinkableResource> getExternal();
+    Single<Link> getExternal();
   }
 
   @Test
@@ -278,7 +277,7 @@ public class RenderLinkedResourceTest {
     TestResourceWithSingleExternalLink resourceImpl = new TestResourceWithSingleExternalLink() {
 
       @Override
-      public Single<LinkableResource> getExternal() {
+      public Single<Link> getExternal() {
         return createSingleExternalLinkedResource(externalLink);
       }
     };

--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/renderer/RenderRelatedResourceTest.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/renderer/RenderRelatedResourceTest.java
@@ -52,25 +52,25 @@ public class RenderRelatedResourceTest {
   public interface ResourceWithManyRelations extends LinkableResource {
 
     @Related("custom:ghi")
-    Single<LinkableResource> getCustomGhi();
+    Single<Link> getCustomGhi();
 
     @Related("item")
-    Single<LinkableResource> getItem();
+    Single<Link> getItem();
 
     @Related("section")
-    Single<LinkableResource> getSection();
+    Single<Link> getSection();
 
     @Related("custom:abc")
-    Single<LinkableResource> getCustomAbc();
+    Single<Link> getCustomAbc();
 
     @Related("canonical")
-    Single<LinkableResource> getCanonical();
+    Single<Link> getCanonical();
 
     @Related("custom:def")
-    Single<LinkableResource> getCustomDef();
+    Single<Link> getCustomDef();
 
     @Related("alternate")
-    Single<LinkableResource> getAlternate();
+    Single<Link> getAlternate();
 
   }
 
@@ -80,37 +80,37 @@ public class RenderRelatedResourceTest {
     ResourceWithManyRelations resourceImpl = new ResourceWithManyRelations() {
 
       @Override
-      public Single<LinkableResource> getSection() {
+      public Single<Link> getSection() {
         return createSingleExternalLinkedResource("/section");
       }
 
       @Override
-      public Single<LinkableResource> getCustomGhi() {
+      public Single<Link> getCustomGhi() {
         return createSingleExternalLinkedResource("/ghi");
       }
 
       @Override
-      public Single<LinkableResource> getItem() {
+      public Single<Link> getItem() {
         return createSingleExternalLinkedResource("/item");
       }
 
       @Override
-      public Single<LinkableResource> getCustomAbc() {
+      public Single<Link> getCustomAbc() {
         return createSingleExternalLinkedResource("/abc");
       }
 
       @Override
-      public Single<LinkableResource> getCanonical() {
+      public Single<Link> getCanonical() {
         return createSingleExternalLinkedResource("/canonical");
       }
 
       @Override
-      public Single<LinkableResource> getCustomDef() {
+      public Single<Link> getCustomDef() {
         return createSingleExternalLinkedResource("/def");
       }
 
       @Override
-      public Single<LinkableResource> getAlternate() {
+      public Single<Link> getAlternate() {
         return createSingleExternalLinkedResource("/alternate");
       }
 
@@ -165,9 +165,7 @@ public class RenderRelatedResourceTest {
         () -> render(resourceImpl));
 
     assertThat(ex).isInstanceOf(HalApiDeveloperException.class)
-        .hasMessageEndingWith(
-            "returns Maybe<TestState>, but it must return an interface annotated with the @HalApiInterface annotation "
-                + "(or a supported generic type that provides such instances, e.g. Observable)");
+        .hasMessageContaining("it must return a Link or an interface annotated with the @HalApiInterface annotation");
   }
 
   @HalApiInterface
@@ -218,9 +216,7 @@ public class RenderRelatedResourceTest {
         () -> render(resourceImpl));
 
     assertThat(ex).isInstanceOf(HalApiDeveloperException.class)
-        .hasMessageEndingWith(
-            "returns Observable<TestState>, but it must return an interface annotated with the @HalApiInterface annotation "
-                + "(or a supported generic type that provides such instances, e.g. Observable)");
+        .hasMessageContaining("it must return a Link or an interface annotated with the @HalApiInterface annotation");
   }
 
   @Test
@@ -249,7 +245,7 @@ public class RenderRelatedResourceTest {
   }
 
   @Test
-  public void should_support_extensions_of_linkable_resource() {
+  public void should_support_plain_external_links() {
 
     ResourceWithCustomLink resourceImpl = new ResourceWithCustomLink() {
 
@@ -259,14 +255,8 @@ public class RenderRelatedResourceTest {
       }
 
       @Override
-      public Single<CustomLinkableResource> getCustomExternal() {
-        return Single.just(new CustomLinkableResource() {
-
-          @Override
-          public Link createLink() {
-            return new Link("/bar");
-          }
-        });
+      public Single<Link> getCustomExternal() {
+        return Single.just(new Link("/bar"));
       }
     };
 
@@ -286,6 +276,6 @@ public class RenderRelatedResourceTest {
   public interface ResourceWithCustomLink extends LinkableResource {
 
     @Related("item")
-    Single<CustomLinkableResource> getCustomExternal();
+    Single<Link> getCustomExternal();
   }
 }

--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/renderer/blocking/RenderLinkedResourceTest.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/renderer/blocking/RenderLinkedResourceTest.java
@@ -181,7 +181,7 @@ public class RenderLinkedResourceTest {
   public interface TestResourceWithRequiredExternalLink {
 
     @Related(LINKED)
-    LinkableResource getExternal();
+    Link getExternal();
   }
 
   @Test
@@ -192,14 +192,8 @@ public class RenderLinkedResourceTest {
     TestResourceWithRequiredExternalLink resourceImpl = new TestResourceWithRequiredExternalLink() {
 
       @Override
-      public LinkableResource getExternal() {
-        return new LinkableResource() {
-
-          @Override
-          public Link createLink() {
-            return externalLink;
-          }
-        };
+      public Link getExternal() {
+        return externalLink;
       }
     };
 
@@ -207,6 +201,26 @@ public class RenderLinkedResourceTest {
 
     assertThat(hal.getLinks(LINKED)).containsExactly(externalLink);
     assertThat(hal.getModel().path("_links").path(LINKED).isObject()).isTrue();
+  }
+
+  @Test
+  public void returning_null_as_external_link_should_throw_exception() {
+
+    TestResourceWithRequiredExternalLink resourceImpl = new TestResourceWithRequiredExternalLink() {
+
+      @Override
+      public Link getExternal() {
+        return null;
+      }
+
+    };
+
+    Throwable ex = catchThrowable(
+        () -> render(resourceImpl));
+
+    assertThat(ex).isInstanceOf(HalApiDeveloperException.class)
+        .hasMessageStartingWith("#getExternal of anonymous")
+        .hasMessageContaining("must not return null");
   }
 
   @Test

--- a/examples/spring-hypermedia/src/main/java/io/wcm/caravan/rhyme/examples/spring/hypermedia/DetailedEmployeeController.java
+++ b/examples/spring-hypermedia/src/main/java/io/wcm/caravan/rhyme/examples/spring/hypermedia/DetailedEmployeeController.java
@@ -25,6 +25,7 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 import java.util.stream.Stream;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
@@ -32,6 +33,7 @@ import org.springframework.web.bind.annotation.RestController;
 import io.wcm.caravan.hal.resource.Link;
 import io.wcm.caravan.rhyme.api.client.HalApiClient;
 import io.wcm.caravan.rhyme.api.exceptions.HalApiClientException;
+import io.wcm.caravan.rhyme.api.resources.LinkableResource;
 import io.wcm.caravan.rhyme.api.server.ResourceConversions;
 import io.wcm.caravan.rhyme.spring.api.SpringRhyme;
 
@@ -137,6 +139,21 @@ class DetailedEmployeeController {
           colleagues = colleagues.map(ResourceConversions::asEmbeddedResourceWithoutLink);
         }
         return colleagues;
+      }
+
+      @Override
+      public LinkableResource getExternalHtmlPage() {
+
+        return new LinkableResource() {
+
+          @Override
+          public Link createLink() {
+            String name = getEmployee().getState().getName();
+            return new Link("https://lotr.fandom.com/wiki/" + name)
+                .setTitle(name + "'s LOTR Wiki page")
+                .setType(MediaType.TEXT_HTML_VALUE);
+          }
+        };
       }
 
       @Override

--- a/examples/spring-hypermedia/src/main/java/io/wcm/caravan/rhyme/examples/spring/hypermedia/DetailedEmployeeController.java
+++ b/examples/spring-hypermedia/src/main/java/io/wcm/caravan/rhyme/examples/spring/hypermedia/DetailedEmployeeController.java
@@ -141,7 +141,7 @@ class DetailedEmployeeController {
       }
 
       @Override
-      public Link getExternalHtmlPage() {
+      public Link getHtmlProfileLink() {
 
         String name = getEmployee().getState().getName();
 

--- a/examples/spring-hypermedia/src/main/java/io/wcm/caravan/rhyme/examples/spring/hypermedia/DetailedEmployeeController.java
+++ b/examples/spring-hypermedia/src/main/java/io/wcm/caravan/rhyme/examples/spring/hypermedia/DetailedEmployeeController.java
@@ -33,7 +33,6 @@ import org.springframework.web.bind.annotation.RestController;
 import io.wcm.caravan.hal.resource.Link;
 import io.wcm.caravan.rhyme.api.client.HalApiClient;
 import io.wcm.caravan.rhyme.api.exceptions.HalApiClientException;
-import io.wcm.caravan.rhyme.api.resources.LinkableResource;
 import io.wcm.caravan.rhyme.api.server.ResourceConversions;
 import io.wcm.caravan.rhyme.spring.api.SpringRhyme;
 
@@ -142,18 +141,13 @@ class DetailedEmployeeController {
       }
 
       @Override
-      public LinkableResource getExternalHtmlPage() {
+      public Link getExternalHtmlPage() {
 
-        return new LinkableResource() {
+        String name = getEmployee().getState().getName();
 
-          @Override
-          public Link createLink() {
-            String name = getEmployee().getState().getName();
-            return new Link("https://lotr.fandom.com/wiki/" + name)
-                .setTitle(name + "'s LOTR Wiki page")
-                .setType(MediaType.TEXT_HTML_VALUE);
-          }
-        };
+        return new Link("https://lotr.fandom.com/wiki/" + name)
+            .setTitle(name + "'s LOTR Wiki page")
+            .setType(MediaType.TEXT_HTML_VALUE);
       }
 
       @Override

--- a/examples/spring-hypermedia/src/main/java/io/wcm/caravan/rhyme/examples/spring/hypermedia/DetailedEmployeeResource.java
+++ b/examples/spring-hypermedia/src/main/java/io/wcm/caravan/rhyme/examples/spring/hypermedia/DetailedEmployeeResource.java
@@ -21,6 +21,7 @@ package io.wcm.caravan.rhyme.examples.spring.hypermedia;
 
 import java.util.stream.Stream;
 
+import io.wcm.caravan.hal.resource.Link;
 import io.wcm.caravan.rhyme.api.annotations.HalApiInterface;
 import io.wcm.caravan.rhyme.api.annotations.Related;
 import io.wcm.caravan.rhyme.api.annotations.ResourceProperty;
@@ -64,5 +65,5 @@ public interface DetailedEmployeeResource extends LinkableResource {
    * @return a link to an external HTML profile page for the employee
    */
   @Related("company:htmlProfile")
-  LinkableResource getExternalHtmlPage();
+  Link getExternalHtmlPage();
 }

--- a/examples/spring-hypermedia/src/main/java/io/wcm/caravan/rhyme/examples/spring/hypermedia/DetailedEmployeeResource.java
+++ b/examples/spring-hypermedia/src/main/java/io/wcm/caravan/rhyme/examples/spring/hypermedia/DetailedEmployeeResource.java
@@ -49,14 +49,20 @@ public interface DetailedEmployeeResource extends LinkableResource {
   String getManagerName();
 
   /**
-   * @return an embedded resource for the manager of this employee
+   * @return the manager of this employee
    */
   @Related("company:manager")
   ManagerResource getManager();
 
   /**
-   * @return embedded resources for every other employee with the same manager
+   * @return every other employee with the same manager
    */
   @Related("company:colleague")
   Stream<EmployeeResource> getColleagues();
+
+  /**
+   * @return a link to an external HTML profile page for the employee
+   */
+  @Related("company:htmlProfile")
+  LinkableResource getExternalHtmlPage();
 }

--- a/examples/spring-hypermedia/src/main/java/io/wcm/caravan/rhyme/examples/spring/hypermedia/DetailedEmployeeResource.java
+++ b/examples/spring-hypermedia/src/main/java/io/wcm/caravan/rhyme/examples/spring/hypermedia/DetailedEmployeeResource.java
@@ -65,5 +65,5 @@ public interface DetailedEmployeeResource extends LinkableResource {
    * @return a link to an external HTML profile page for the employee
    */
   @Related("company:htmlProfile")
-  Link getExternalHtmlPage();
+  Link getHtmlProfileLink();
 }

--- a/examples/spring-hypermedia/src/test/java/io/wcm/caravan/rhyme/examples/spring/hypermedia/AbstractCompanyApiIT.java
+++ b/examples/spring-hypermedia/src/test/java/io/wcm/caravan/rhyme/examples/spring/hypermedia/AbstractCompanyApiIT.java
@@ -245,7 +245,7 @@ abstract class AbstractCompanyApiIT {
 
     Long firstId = getIdOfFirstEmployee();
 
-    Link external = api.getDetailedEmployeeById(firstId).getExternalHtmlPage();
+    Link external = api.getDetailedEmployeeById(firstId).getHtmlProfileLink();
 
     assertThat(external.getHref())
         .endsWith("/" + api.getEmployeeById(firstId).getState().getName());

--- a/examples/spring-hypermedia/src/test/java/io/wcm/caravan/rhyme/examples/spring/hypermedia/AbstractCompanyApiIT.java
+++ b/examples/spring-hypermedia/src/test/java/io/wcm/caravan/rhyme/examples/spring/hypermedia/AbstractCompanyApiIT.java
@@ -245,7 +245,7 @@ abstract class AbstractCompanyApiIT {
 
     Long firstId = getIdOfFirstEmployee();
 
-    Link external = api.getDetailedEmployeeById(firstId).getExternalHtmlPage().createLink();
+    Link external = api.getDetailedEmployeeById(firstId).getExternalHtmlPage();
 
     assertThat(external.getHref())
         .endsWith("/" + api.getEmployeeById(firstId).getState().getName());

--- a/examples/spring-hypermedia/src/test/java/io/wcm/caravan/rhyme/examples/spring/hypermedia/AbstractCompanyApiIT.java
+++ b/examples/spring-hypermedia/src/test/java/io/wcm/caravan/rhyme/examples/spring/hypermedia/AbstractCompanyApiIT.java
@@ -32,7 +32,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.internal.util.collections.Iterables;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
 
+import io.wcm.caravan.hal.resource.Link;
 import io.wcm.caravan.rhyme.api.exceptions.HalApiClientException;
 import io.wcm.caravan.rhyme.api.exceptions.HalApiServerException;
 
@@ -236,6 +238,20 @@ abstract class AbstractCompanyApiIT {
     Manager manager = api.getDetailedEmployeeById(firstId).getManager().getState();
 
     assertThat(manager.getName()).isEqualTo("Gandalf");
+  }
+
+  @Test
+  public void getDetailedEmployeeById_should_provide_external_link() throws Exception {
+
+    Long firstId = getIdOfFirstEmployee();
+
+    Link external = api.getDetailedEmployeeById(firstId).getExternalHtmlPage().createLink();
+
+    assertThat(external.getHref())
+        .endsWith("/" + api.getEmployeeById(firstId).getState().getName());
+
+    assertThat(external.getType())
+        .isEqualTo(MediaType.TEXT_HTML_VALUE);
   }
 
   private void assertThat404isReturnedFor(ThrowingCallable codeThatThrows) {

--- a/examples/spring-hypermedia/src/test/java/io/wcm/caravan/rhyme/examples/spring/hypermedia/ClientPreferencesIT.java
+++ b/examples/spring-hypermedia/src/test/java/io/wcm/caravan/rhyme/examples/spring/hypermedia/ClientPreferencesIT.java
@@ -123,6 +123,10 @@ public class ClientPreferencesIT extends MockMvcClientIT {
 
   private boolean isLinkThatShouldHaveStickyParameter(Entry<String, Link> entry) {
 
+    if (entry.getValue().getType() != null) {
+      return false;
+    }
+
     String relation = entry.getKey();
 
     return !(relation.equals("curies") || relation.equals("company:preferences"));

--- a/integration/aem/src/main/java/io/wcm/caravan/rhyme/aem/impl/resources/AemApiDiscoveryResource.java
+++ b/integration/aem/src/main/java/io/wcm/caravan/rhyme/aem/impl/resources/AemApiDiscoveryResource.java
@@ -21,6 +21,7 @@ package io.wcm.caravan.rhyme.aem.impl.resources;
 
 import java.util.List;
 
+import io.wcm.caravan.hal.resource.Link;
 import io.wcm.caravan.rhyme.aem.api.RhymeResourceRegistration;
 import io.wcm.caravan.rhyme.aem.api.adaptation.SlingResourceAdapter;
 import io.wcm.caravan.rhyme.api.annotations.HalApiInterface;
@@ -43,5 +44,5 @@ public interface AemApiDiscoveryResource {
    * @return a list of {@link LinkableResource} used to create the link
    */
   @Related("hal:api")
-  List<LinkableResource> getApiEntryPoints();
+  List<Link> getApiEntryPoints();
 }

--- a/integration/aem/src/main/java/io/wcm/caravan/rhyme/aem/impl/resources/AemApiDiscoveryResourceImpl.java
+++ b/integration/aem/src/main/java/io/wcm/caravan/rhyme/aem/impl/resources/AemApiDiscoveryResourceImpl.java
@@ -27,6 +27,7 @@ import javax.inject.Inject;
 
 import org.apache.sling.models.annotations.Model;
 
+import io.wcm.caravan.hal.resource.Link;
 import io.wcm.caravan.rhyme.aem.api.SlingRhyme;
 import io.wcm.caravan.rhyme.aem.api.resources.AbstractLinkableResource;
 import io.wcm.caravan.rhyme.aem.impl.RhymeResourceRegistry;
@@ -41,11 +42,12 @@ public class AemApiDiscoveryResourceImpl extends AbstractLinkableResource implem
   private RhymeResourceRegistry registry;
 
   @Override
-  public List<LinkableResource> getApiEntryPoints() {
+  public List<Link> getApiEntryPoints() {
 
     rhyme.setResponseMaxAge(Duration.ofSeconds(MAX_AGE_SECONDS));
 
     return registry.getAllApiEntryPoints(resourceAdapter)
+        .map(LinkableResource::createLink)
         .collect(Collectors.toList());
   }
 

--- a/integration/aem/src/test/java/io/wcm/caravan/rhyme/aem/impl/resources/AemApiDiscoveryResourceImplTest.java
+++ b/integration/aem/src/test/java/io/wcm/caravan/rhyme/aem/impl/resources/AemApiDiscoveryResourceImplTest.java
@@ -35,7 +35,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import io.wcm.caravan.hal.resource.Link;
 import io.wcm.caravan.rhyme.aem.api.RhymeResourceRegistration;
 import io.wcm.caravan.rhyme.aem.api.SlingRhyme;
-import io.wcm.caravan.rhyme.aem.impl.resources.AemApiDiscoveryResourceImpl;
 import io.wcm.caravan.rhyme.aem.testing.context.AppAemContext;
 import io.wcm.caravan.rhyme.aem.testing.models.SelectorSlingTestResource;
 import io.wcm.caravan.rhyme.aem.testing.models.TestResourceRegistration;
@@ -81,12 +80,14 @@ public class AemApiDiscoveryResourceImplTest {
   @Test
   void getAllEntryPoints_should_return_single_entrypoint_from_testResourceSelectorProvider() {
 
-    List<LinkableResource> entryPoints = resource.getApiEntryPoints();
+    List<Link> entryPoints = resource.getApiEntryPoints();
 
     assertThat(entryPoints)
         .hasSize(1)
         .first()
-        .isInstanceOf(SelectorSlingTestResource.class);
+        .extracting(Link::getHref)
+        .asString()
+        .contains("." + SelectorSlingTestResource.SELECTOR + ".");
   }
 
   @Test
@@ -95,11 +96,10 @@ public class AemApiDiscoveryResourceImplTest {
     Mockito.when(mockRegistration.getApiEntryPoint(ArgumentMatchers.any()))
         .thenAnswer(invocation -> Optional.of(new TestEntryPointResource()));
 
-    List<LinkableResource> entryPoints = resource.getApiEntryPoints();
+    List<Link> entryPoints = resource.getApiEntryPoints();
 
     assertThat(entryPoints)
         .hasSize(2)
-        .extracting(LinkableResource::createLink)
         .extracting(Link::getHref)
         .containsExactlyInAnyOrder("/foo", "/.selectortest.rhyme");
   }

--- a/testing/src/test/java/io/wcm/caravan/rhyme/testing/client/HalCrawlerTest.java
+++ b/testing/src/test/java/io/wcm/caravan/rhyme/testing/client/HalCrawlerTest.java
@@ -24,6 +24,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
 
+import com.google.common.collect.ImmutableList;
+
 import io.reactivex.rxjava3.core.Single;
 import io.wcm.caravan.hal.resource.HalResource;
 import io.wcm.caravan.hal.resource.Link;
@@ -102,6 +104,20 @@ public class HalCrawlerTest {
         .hasSize(10)
         .extracting(HalResponse::getUri)
         .containsExactly("/", "/1", "/2", "/3", "/4", "/5", "/6", "/7", "/8", "/9");
+  }
+
+  @Test
+  public void should_ignore_relations() throws Exception {
+
+    MockResourceChainLoader loader = new MockResourceChainLoader();
+
+    HalCrawler crawler = new HalCrawler(loader)
+        .withIgnoredRelations(ImmutableList.of(StandardRelations.NEXT));
+
+    assertThat(crawler.getAllResponses())
+        .hasSize(1)
+        .extracting(HalResponse::getUri)
+        .containsExactly("/");
   }
 
   @Test

--- a/testing/src/test/java/io/wcm/caravan/rhyme/testing/client/HalCrawlerTest.java
+++ b/testing/src/test/java/io/wcm/caravan/rhyme/testing/client/HalCrawlerTest.java
@@ -21,6 +21,9 @@ package io.wcm.caravan.rhyme.testing.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
 
@@ -121,6 +124,36 @@ public class HalCrawlerTest {
   }
 
   @Test
+  public void should_filter_links_with_custom_content_type() throws Exception {
+
+    MockResourceChainLoader loader = new MockResourceChainLoader()
+        .withAdditionalLink(new Link("/foo").setType("text/html"));
+
+    HalCrawler crawler = new HalCrawler(loader)
+        .withLimit(10);
+
+    assertThat(crawler.getAllResponses())
+        .hasSize(10)
+        .extracting(HalResponse::getUri)
+        .doesNotContain("/foo");
+  }
+
+  @Test
+  public void should_not_filter_links_with_hal_content_type() throws Exception {
+
+    MockResourceChainLoader loader = new MockResourceChainLoader()
+        .withAdditionalLink(new Link("/foo").setType(HalResource.CONTENT_TYPE));
+
+    HalCrawler crawler = new HalCrawler(loader)
+        .withLimit(10);
+
+    assertThat(crawler.getAllResponses())
+        .hasSize(10)
+        .extracting(HalResponse::getUri)
+        .contains("/foo");
+  }
+
+  @Test
   public void should_not_crawl_multiple_times() throws Exception {
 
     MockResourceChainLoader loader = new MockResourceChainLoader()
@@ -163,6 +196,8 @@ public class HalCrawlerTest {
 
     private boolean includeLinkTemplate;
 
+    private List<Link> additionalLinks = new ArrayList<>();
+
     MockResourceChainLoader withLinkTemplate() {
       includeLinkTemplate = true;
       return this;
@@ -170,6 +205,12 @@ public class HalCrawlerTest {
 
     MockResourceChainLoader withLimit(int maxNumResources) {
       this.limit = maxNumResources;
+      return this;
+    }
+
+
+    MockResourceChainLoader withAdditionalLink(Link link) {
+      this.additionalLinks.add(link);
       return this;
     }
 
@@ -186,6 +227,8 @@ public class HalCrawlerTest {
         body.addLinks("foo:template", new Link("/{index}"));
         body.addLinks("curies", new Link("/docs/foo").setName("foo"));
       }
+
+      body.addLinks("additional", additionalLinks);
 
       return Single.just(new HalResponse()
           .withStatus(200)


### PR DESCRIPTION
Sometimes you do need to create links to resources for which there is no corresponding HalApiInterface. 

In that case there is now full support to have your Related methods return a Link instance directly. (or wrapped in List, Observable etc). Previously there was support for returning anonymous LinkableResoure instances, but this was limited to rendering only and calling createLink on the proxy would fail.

Since createLink is the only method you can call anyway, it makes more sense to return the link directly.