### PR TITLE
Improved error handling for CaravanJsonPipelineResourceLoader

### DIFF
--- a/integration/osgi-jaxrs/src/main/java/io/wcm/caravan/rhyme/caravan/impl/CaravanJsonPipelineResourceLoader.java
+++ b/integration/osgi-jaxrs/src/main/java/io/wcm/caravan/rhyme/caravan/impl/CaravanJsonPipelineResourceLoader.java
@@ -24,7 +24,6 @@ import java.util.concurrent.TimeUnit;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import hu.akarnokd.rxjava3.interop.RxJavaInterop;
@@ -113,15 +112,13 @@ class CaravanJsonPipelineResourceLoader implements HalResourceLoader {
 
   private JsonNode tryToReadResponseBodyFromException(JsonPipelineInputException jpie) {
 
-    JsonNode responseNode = JsonNodeFactory.instance.objectNode();
-
     Throwable cause = jpie.getCause();
     if (cause instanceof IllegalResponseRuntimeException) {
       IllegalResponseRuntimeException irre = ((IllegalResponseRuntimeException)cause);
       String responseBody = irre.getResponseBody();
       if (responseBody != null) {
         try {
-          responseNode = JSON_FACTORY.createParser(responseBody).readValueAs(ObjectNode.class);
+          return JSON_FACTORY.createParser(responseBody).readValueAs(ObjectNode.class);
         }
         // CHECKSTYLE:OFF - we really want to just try to parse the response body as JSON if possible
         catch (Exception ex) {
@@ -130,6 +127,6 @@ class CaravanJsonPipelineResourceLoader implements HalResourceLoader {
       }
     }
 
-    return responseNode;
+    return null;
   }
 }

--- a/integration/osgi-jaxrs/src/main/java/io/wcm/caravan/rhyme/caravan/impl/CaravanJsonPipelineResourceLoader.java
+++ b/integration/osgi-jaxrs/src/main/java/io/wcm/caravan/rhyme/caravan/impl/CaravanJsonPipelineResourceLoader.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import hu.akarnokd.rxjava3.interop.RxJavaInterop;
 import io.reactivex.rxjava3.core.Single;
@@ -43,6 +44,8 @@ import io.wcm.caravan.rhyme.api.spi.HalResourceLoader;
 
 
 class CaravanJsonPipelineResourceLoader implements HalResourceLoader {
+
+  private static final JsonFactory JSON_FACTORY = new JsonFactory(new ObjectMapper());
 
   private final JsonPipelineFactory pipelineFactory;
   private final String serviceId;
@@ -96,12 +99,14 @@ class CaravanJsonPipelineResourceLoader implements HalResourceLoader {
 
     JsonPipelineInputException jpie = (JsonPipelineInputException)ex;
 
-    JsonNode responseNode = tryToReadResponseBodyFromException(jpie);
-
     HalResponse errorResponse = new HalResponse()
         .withUri(uri)
-        .withStatus(jpie.getStatusCode())
-        .withBody(responseNode);
+        .withStatus(jpie.getStatusCode());
+
+    JsonNode responseNode = tryToReadResponseBodyFromException(jpie);
+    if (responseNode != null) {
+      errorResponse = errorResponse.withBody(responseNode);
+    }
 
     return Single.error(new HalApiClientException(errorResponse, ex));
   }
@@ -116,7 +121,7 @@ class CaravanJsonPipelineResourceLoader implements HalResourceLoader {
       String responseBody = irre.getResponseBody();
       if (responseBody != null) {
         try {
-          responseNode = new JsonFactory(new ObjectMapper()).createParser(responseBody).readValueAs(JsonNode.class);
+          responseNode = JSON_FACTORY.createParser(responseBody).readValueAs(ObjectNode.class);
         }
         // CHECKSTYLE:OFF - we really want to just try to parse the response body as JSON if possible
         catch (Exception ex) {

--- a/integration/osgi-jaxrs/src/test/java/io/wcm/caravan/rhyme/caravan/impl/AbstractCaravanJsonResourceLoaderTest.java
+++ b/integration/osgi-jaxrs/src/test/java/io/wcm/caravan/rhyme/caravan/impl/AbstractCaravanJsonResourceLoaderTest.java
@@ -166,6 +166,17 @@ abstract class AbstractCaravanJsonResourceLoaderTest {
   }
 
   @Test
+  public void getHalResource_should_throw_HalApiClientException_for_500_responses_with_status_code_in_body() throws Exception {
+
+    mockIllegalResponseRuntimeException(500, "500 Internal Server Error");
+
+    Throwable ex = catchThrowable(this::getHalResponse);
+
+    assertThat(ex).isInstanceOf(HalApiClientException.class)
+        .hasMessageContaining("has failed with status code 500");
+  }
+
+  @Test
   public void getHalResource_should_throw_HalApiClientException_for_unexpected_exceptions() throws Exception {
 
     // trigger a runtime exception within JsonPipeline by having the http client return an unexpected empty observable

--- a/integration/osgi-jaxrs/src/test/java/io/wcm/caravan/rhyme/caravan/impl/AbstractCaravanJsonResourceLoaderTest.java
+++ b/integration/osgi-jaxrs/src/test/java/io/wcm/caravan/rhyme/caravan/impl/AbstractCaravanJsonResourceLoaderTest.java
@@ -174,6 +174,9 @@ abstract class AbstractCaravanJsonResourceLoaderTest {
 
     assertThat(ex).isInstanceOf(HalApiClientException.class)
         .hasMessageContaining("has failed with status code 500");
+
+    assertThat(((HalApiClientException)ex).getErrorResponse().getBody())
+        .isNull();
   }
 
   @Test

--- a/testing/src/main/java/io/wcm/caravan/rhyme/testing/client/AbstractHalResourceLoaderTest.java
+++ b/testing/src/main/java/io/wcm/caravan/rhyme/testing/client/AbstractHalResourceLoaderTest.java
@@ -130,11 +130,16 @@ public abstract class AbstractHalResourceLoaderTest {
 
   private static void stubHtmlResponseWithStatusCode(int statusCode) {
 
+    stubResponseWithContentTypeAndBody(statusCode, "text/html", "<h1>This is an HTML document</h1>");
+  }
+
+  private static void stubResponseWithContentTypeAndBody(int statusCode, String contentType, String body) {
+
     wireMockServer.stubFor(get(urlEqualTo(TEST_PATH))
         .willReturn(aResponse()
             .withStatus(statusCode)
-            .withHeader(HttpHeaders.CONTENT_TYPE, "text/html")
-            .withBody("<h1>This is an HTML document</h1>")));
+            .withHeader(HttpHeaders.CONTENT_TYPE, contentType)
+            .withBody(body)));
   }
 
   private static void stubJsonResponseWithStatusCode(int statusCode) {
@@ -156,11 +161,7 @@ public abstract class AbstractHalResourceLoaderTest {
 
   private static void stub500VndErrorResponse() {
 
-    wireMockServer.stubFor(get(urlEqualTo(TEST_PATH))
-        .willReturn(aResponse()
-            .withStatus(500)
-            .withHeader(HttpHeaders.CONTENT_TYPE.toLowerCase(), VndErrorResponseRenderer.CONTENT_TYPE)
-            .withBody("{}")));
+    stubResponseWithContentTypeAndBody(500, VndErrorResponseRenderer.CONTENT_TYPE, "{}");
   }
 
   private void stubEmptyResponseWithStatusCode(int statusCode) {
@@ -177,7 +178,6 @@ public abstract class AbstractHalResourceLoaderTest {
             .withStatus(statusCode)
             .withFault(fault)));
   }
-
 
   protected HalResponse loadResource() {
 
@@ -378,6 +378,19 @@ public abstract class AbstractHalResourceLoaderTest {
   public void error_body_should_be_null_in_HalApiClientException_for_non_ok_response_without_body() throws Exception {
 
     stubEmptyResponseWithStatusCode(204);
+
+    HalApiClientException ex = loadResourceAndExpectClientException();
+
+    assertThat(ex.getErrorResponse())
+        .isNotNull();
+    assertThat(ex.getErrorResponse().getBody())
+        .isNull();
+  }
+
+  @Test
+  public void error_body_should_be_null_in_HalApiClientException_for_non_ok_text_response() throws Exception {
+
+    stubResponseWithContentTypeAndBody(500, "text/json", "500");
 
     HalApiClientException ex = loadResourceAndExpectClientException();
 


### PR DESCRIPTION
CaravanJsonPipelineResourceLoader failed if a response was seaminly JSON, but not a full object node