### PR TITLE
Update/sync testing dependencies

### DIFF
--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/client/ProxyCachingTest.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/client/ProxyCachingTest.java
@@ -24,8 +24,8 @@ import static io.wcm.caravan.rhyme.api.relations.StandardRelations.ITEM;
 import static io.wcm.caravan.rhyme.impl.client.ClientTestSupport.ENTRY_POINT_URI;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 
 import java.util.List;
 
@@ -107,7 +107,7 @@ public class ProxyCachingTest {
 
     assertThat(proxy1).isSameAs(proxy2);
 
-    verifyZeroInteractions(client.getMockJsonLoader());
+    verifyNoInteractions(client.getMockJsonLoader());
   }
 
   @HalApiInterface
@@ -127,7 +127,7 @@ public class ProxyCachingTest {
 
     assertThat(proxy1).isNotSameAs(proxy2);
 
-    verifyZeroInteractions(client.getMockJsonLoader());
+    verifyNoInteractions(client.getMockJsonLoader());
   }
 
   @Test
@@ -140,7 +140,7 @@ public class ProxyCachingTest {
 
     assertThat(state1).isSameAs(state2);
 
-    verifyZeroInteractions(client.getMockJsonLoader());
+    verifyNoInteractions(client.getMockJsonLoader());
   }
 
   @Test
@@ -153,7 +153,7 @@ public class ProxyCachingTest {
 
     assertThat(linked1).isSameAs(linked2);
 
-    verifyZeroInteractions(client.getMockJsonLoader());
+    verifyNoInteractions(client.getMockJsonLoader());
   }
 
   @Test

--- a/examples/aem-hal-browser/parent/pom.xml
+++ b/examples/aem-hal-browser/parent/pom.xml
@@ -204,7 +204,7 @@
       <dependency>
         <groupId>io.wcm</groupId>
         <artifactId>io.wcm.testing.aem-mock.junit5</artifactId>
-        <version>4.0.4</version>
+        <version>4.1.8</version>
       </dependency>
       <dependency>
         <groupId>org.apache.sling</groupId>
@@ -214,7 +214,7 @@
       <dependency>
         <groupId>org.apache.sling</groupId>
         <artifactId>org.apache.sling.testing.caconfig-mock-plugin</artifactId>
-        <version>1.3.2</version>
+        <version>1.4.0</version>
       </dependency>
       <dependency>
         <groupId>io.wcm</groupId>

--- a/integration/aem/pom.xml
+++ b/integration/aem/pom.xml
@@ -153,7 +153,7 @@
       <groupId>io.wcm</groupId>
       <artifactId>io.wcm.testing.aem-mock.junit5</artifactId>
       <scope>test</scope>
-      <version>4.0.4</version>
+      <version>4.1.8</version>
     </dependency>
     <dependency>
       <groupId>org.apache.sling</groupId>
@@ -165,7 +165,7 @@
       <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.testing.caconfig-mock-plugin</artifactId>
       <scope>test</scope>
-      <version>1.3.2</version>
+      <version>1.4.0</version>
     </dependency>
     <dependency>
       <groupId>io.wcm</groupId>
@@ -194,7 +194,7 @@
     <dependency>
       <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.testing.osgi-mock.junit5</artifactId>
-      <version>2.4.16</version>
+      <version>3.2.2</version>
       <scope>test</scope>
     </dependency>
 

--- a/integration/aem/src/test/java/io/wcm/caravan/rhyme/aem/impl/docs/RhymeDocsBundleTrackerTest.java
+++ b/integration/aem/src/test/java/io/wcm/caravan/rhyme/aem/impl/docs/RhymeDocsBundleTrackerTest.java
@@ -22,7 +22,7 @@ package io.wcm.caravan.rhyme.aem.impl.docs;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import org.apache.sling.testing.mock.osgi.MockOsgi;
 import org.apache.sling.testing.mock.osgi.junit.OsgiContext;
@@ -37,8 +37,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleEvent;
 
-import io.wcm.caravan.rhyme.aem.impl.docs.RhymeDocsBundleTracker;
-import io.wcm.caravan.rhyme.aem.impl.docs.RhymeDocsOsgiBundleSupport;
 import io.wcm.caravan.rhyme.api.spi.RhymeDocsSupport;
 
 
@@ -99,7 +97,7 @@ public class RhymeDocsBundleTrackerTest {
 
     startBundle(bundleWithoutDocs);
 
-    verifyZeroInteractions(docsSupport);
+    verifyNoInteractions(docsSupport);
   }
 
   @Test
@@ -137,7 +135,7 @@ public class RhymeDocsBundleTrackerTest {
 
     stopBundle(bundleWithoutDocs);
 
-    verifyZeroInteractions(docsSupport);
+    verifyNoInteractions(docsSupport);
   }
 
 }

--- a/integration/osgi-jaxrs/pom.xml
+++ b/integration/osgi-jaxrs/pom.xml
@@ -192,7 +192,7 @@
     <dependency>
       <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.testing.osgi-mock.junit5</artifactId>
-      <version>2.4.16</version>
+      <version>3.2.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/integration/osgi-jaxrs/src/test/java/io/wcm/caravan/rhyme/caravan/impl/CaravanHalApiClientImplTest.java
+++ b/integration/osgi-jaxrs/src/test/java/io/wcm/caravan/rhyme/caravan/impl/CaravanHalApiClientImplTest.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import java.time.Duration;
 
@@ -138,7 +138,7 @@ public class CaravanHalApiClientImplTest {
 
     // no HTTP requests will be made before the state is accessed
     assertThat(resource).isNotNull();
-    verifyZeroInteractions(httpClient);
+    verifyNoInteractions(httpClient);
 
     // but when it is accessed, a single http client request will be executed
     assertThat(resource.getState()).isNotNull();

--- a/integration/osgi-jaxrs/src/test/java/io/wcm/caravan/rhyme/caravan/impl/CaravanRhymeRequestCycleImplTest.java
+++ b/integration/osgi-jaxrs/src/test/java/io/wcm/caravan/rhyme/caravan/impl/CaravanRhymeRequestCycleImplTest.java
@@ -23,7 +23,7 @@ import static org.apache.http.HttpStatus.SC_NOT_IMPLEMENTED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.net.URI;
@@ -123,7 +123,7 @@ public class CaravanRhymeRequestCycleImplTest {
 
     LinkableTestResource resource = rhyme.getRemoteResource("/serviceId", REQUEST_URI, LinkableTestResource.class);
 
-    verifyZeroInteractions(httpClient);
+    verifyNoInteractions(httpClient);
 
     assertThat(resource.getState()).isNotNull();
     verify(httpClient).execute(ArgumentMatchers.any());

--- a/integration/osgi-jaxrs/src/test/java/io/wcm/caravan/rhyme/jaxrs/impl/docs/RhymeDocsBundleTrackerTest.java
+++ b/integration/osgi-jaxrs/src/test/java/io/wcm/caravan/rhyme/jaxrs/impl/docs/RhymeDocsBundleTrackerTest.java
@@ -22,7 +22,7 @@ package io.wcm.caravan.rhyme.jaxrs.impl.docs;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import org.apache.sling.testing.mock.osgi.MockOsgi;
 import org.apache.sling.testing.mock.osgi.junit.OsgiContext;
@@ -96,7 +96,7 @@ public class RhymeDocsBundleTrackerTest {
 
     startBundle(bundleWithoutDocs);
 
-    verifyZeroInteractions(docsSupport);
+    verifyNoInteractions(docsSupport);
   }
 
   @Test
@@ -134,6 +134,6 @@ public class RhymeDocsBundleTrackerTest {
 
     stopBundle(bundleWithoutDocs);
 
-    verifyZeroInteractions(docsSupport);
+    verifyNoInteractions(docsSupport);
   }
 }

--- a/integration/spring/src/test/java/io/wcm/caravan/rhyme/spring/impl/UrlFingerprintingImplTest.java
+++ b/integration/spring/src/test/java/io/wcm/caravan/rhyme/spring/impl/UrlFingerprintingImplTest.java
@@ -22,7 +22,7 @@ package io.wcm.caravan.rhyme.spring.impl;
 import static io.wcm.caravan.rhyme.spring.impl.SpringLinkBuilderTestController.BASE_PATH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
@@ -175,7 +175,7 @@ public class UrlFingerprintingImplTest {
 
     assertThatFingerprintContains(fingerprinting, valueFromRequest);
 
-    verifyZeroInteractions(rhyme);
+    verifyNoInteractions(rhyme);
   }
 
   @Test

--- a/tooling/parent/pom.xml
+++ b/tooling/parent/pom.xml
@@ -118,6 +118,18 @@
         <version>1.0.0</version>
       </dependency>
 
+      <!-- Use lastest Mockito version as we are using JUnit 5 -->
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>4.2.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-junit-jupiter</artifactId>
+        <version>4.2.0</version>
+      </dependency>
+
     </dependencies>
 
   </dependencyManagement>


### PR DESCRIPTION
i updated some testing dependencies to latest versions in https://github.com/wcm-io-caravan/caravan-tooling/commit/05e06c038950953a1dda39240d540161f467eaff

this leads to a failed unit test in rhyme (develop branch is also affected!)

i tried to cleanup several testing dependencies in this, including updating to latest mockito version (parent_toplevel uses a very outdated version to keep compatibility with junit4).

please check the root cause of the failing unit test in io.wcm.caravan.rhyme.aem