### PR TITLE
Reduced expectations in AbstractHalResourceLoaderTest

### DIFF
--- a/integration/aem/pom.xml
+++ b/integration/aem/pom.xml
@@ -119,7 +119,7 @@
     <dependency>
       <groupId>io.wcm.caravan</groupId>
       <artifactId>io.wcm.caravan.rhyme.testing</artifactId>
-      <version>1.0.0</version>
+      <version>1.0.1-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
 

--- a/integration/spring/changes.xml
+++ b/integration/spring/changes.xml
@@ -23,6 +23,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="1.0.2" date="not released">
+      <action type="add" dev="ssauder">
+        Reduced expectations in AbstractHalResourceLoaderTest on how exactly malformed responses are handled by client implementations. 
+      </action>
+    </release>
+
     <release version="1.0.0" date="2022-01-12">
       <action type="add" dev="ssauder">
         Initial release.

--- a/integration/spring/pom.xml
+++ b/integration/spring/pom.xml
@@ -129,7 +129,7 @@
     <dependency>
       <groupId>io.wcm.caravan</groupId>
       <artifactId>io.wcm.caravan.rhyme.testing</artifactId>
-      <version>1.0.0</version>
+      <version>1.0.1-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
 

--- a/integration/spring/src/test/java/io/wcm/caravan/rhyme/spring/impl/WebClientSupportTest.java
+++ b/integration/spring/src/test/java/io/wcm/caravan/rhyme/spring/impl/WebClientSupportTest.java
@@ -24,8 +24,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 import org.springframework.web.reactive.function.client.WebClientRequestException;
 
-import com.github.tomakehurst.wiremock.http.Fault;
-
 import io.wcm.caravan.rhyme.api.exceptions.HalApiClientException;
 import io.wcm.caravan.rhyme.api.spi.HalResourceLoader;
 import io.wcm.caravan.rhyme.testing.client.AbstractHalResourceLoaderTest;
@@ -43,24 +41,6 @@ public class WebClientSupportTest extends AbstractHalResourceLoaderTest {
 
   // after upgrading to Spring Boot 2.5.8, WebClient is handling a few edge cases differently,
   // so for now we are overriding the text with updated expectations
-
-  @Override
-  @Test
-  public void cause_should_be_present_in_HalApiClientException_for_malformed_200_response() throws Exception {
-
-    stubFaultyResponseWithStatusCode(200, Fault.MALFORMED_RESPONSE_CHUNK);
-
-    HalApiClientException ex = loadResourceAndExpectClientException();
-
-    assertThat(ex.getStatusCode())
-        .isEqualTo(200);
-
-    assertThat(ex.getErrorResponse().getBody())
-        .isNull();
-
-    assertThat(ex)
-        .hasRootCauseMessage("The response body was completely empty (or consisted only of whitespace)");
-  }
 
   @Override
   @Test

--- a/testing/src/main/java/io/wcm/caravan/rhyme/testing/client/AbstractHalResourceLoaderTest.java
+++ b/testing/src/main/java/io/wcm/caravan/rhyme/testing/client/AbstractHalResourceLoaderTest.java
@@ -478,10 +478,10 @@ public abstract class AbstractHalResourceLoaderTest {
     HalApiClientException ex = loadResourceAndExpectClientException();
 
     // the behaviour for this edge cases varies between implementations:
-    // sometimes the response code is sucessfully extracted, sometimes not.
-    // the only thing they have in common is that at some point, an IOException is caught
-    assertThat(ex)
-        .hasRootCauseInstanceOf(IOException.class);
+    // sometimes the response code is successfully extracted, sometimes not.
+    // the only thing they have in common is that at some point, an Exception is caught
+    assertThat(ex.getCause())
+        .isNotNull();
   }
 
   @Test


### PR DESCRIPTION
the test cases in AbstractHalResourceLoaderTest try to verify whether the root cause actually point to the  underlyingclient / network issue (and are not just some random RuntimeExceptions from the HalResourceLoader wrapper).

But in case of the malformed Fault.MALFORMED_RESPONSE_CHUNK, I'm giving up on this, as the exact behaviour can differ for various reasons (and the root cause is not relevant for application logic anyway)