### PR TITLE
Simplifiy generics in signature of HalApiReturnTypeSupport#convertToObservable

### DIFF
--- a/core/changes.xml
+++ b/core/changes.xml
@@ -23,6 +23,16 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="1.1.2" date="not released">
+      <action type="update" dev="ssauder">
+        Improved reliability when parsing max-age response header.
+      </action>
+     <action type="update" dev="ssauder">
+        Simplified generics in signature of HalApiReturnTypeSupport#convertToObservable. The change is binary compatible at runtime,
+        but (only) if you are implementing your own HalApiReturnTypeSupport, you may see a build error after upgrading the compile time dependency.
+      </action>
+    </release>
+
     <release version="1.1.0" date="2022-01-12">
       <action type="add" dev="ssauder">
         Added functions in builder to specify custom ObjectMapper (to avoid jackson-datatype-guava dependency).

--- a/core/src/main/java/io/wcm/caravan/rhyme/api/spi/HalApiReturnTypeSupport.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/api/spi/HalApiReturnTypeSupport.java
@@ -46,7 +46,7 @@ public interface HalApiReturnTypeSupport {
    * @return a function that will create an {@link Observable} from an instance of the given type,
    *         or null if this is not possible
    */
-  Function<? super Object, Observable<?>> convertToObservable(Class<?> sourceType);
+  Function<Object, Observable<Object>> convertToObservable(Class<?> sourceType);
 
   /**
    * @param returnType the return type of an annotated method

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/RelatedResourceHandler.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/RelatedResourceHandler.java
@@ -55,7 +55,7 @@ class RelatedResourceHandler {
     this.annotationSupport = annotationSupport;
   }
 
-  Observable<?> handleMethodInvocation(HalApiMethodInvocation invocation) {
+  Observable<Object> handleMethodInvocation(HalApiMethodInvocation invocation) {
 
     // check which relation should be followed and what type of objects the Observable emits
     String relation = invocation.getRelation();

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/reflection/CompositeHalApiTypeSupport.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/reflection/CompositeHalApiTypeSupport.java
@@ -115,7 +115,7 @@ public class CompositeHalApiTypeSupport implements HalApiTypeSupport {
   }
 
   @Override
-  public Function<? super Object, Observable<?>> convertToObservable(Class<?> sourceType) {
+  public Function<Object, Observable<Object>> convertToObservable(Class<?> sourceType) {
 
     return firstNonNull(delegate -> delegate.convertToObservable(sourceType));
   }

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/reflection/DefaultHalApiTypeSupport.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/reflection/DefaultHalApiTypeSupport.java
@@ -142,7 +142,7 @@ public class DefaultHalApiTypeSupport implements HalApiTypeSupport {
   }
 
   @Override
-  public Function<? super Object, Observable<?>> convertToObservable(Class<?> sourceType) {
+  public Function<Object, Observable<Object>> convertToObservable(Class<?> sourceType) {
 
     if (Observable.class.isAssignableFrom(sourceType)) {
       return o -> (Observable)o;
@@ -167,7 +167,11 @@ public class DefaultHalApiTypeSupport implements HalApiTypeSupport {
       return o -> Observable.fromIterable((List<?>)o);
     }
     if (Stream.class.isAssignableFrom(sourceType)) {
-      return o -> Observable.fromStream((Stream<?>)o);
+      return o -> {
+        @SuppressWarnings("unchecked")
+        Stream<Object> stream = (Stream<Object>)o;
+        return Observable.fromStream(stream);
+      };
     }
     if (sourceType.getTypeParameters().length == 0) {
       return o -> Observable.just(o);

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/reflection/HalApiTypeSupportAdapter.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/reflection/HalApiTypeSupportAdapter.java
@@ -114,7 +114,7 @@ public class HalApiTypeSupportAdapter implements HalApiTypeSupport {
   }
 
   @Override
-  public Function<? super Object, Observable<?>> convertToObservable(Class<?> sourceType) {
+  public Function<Object, Observable<Object>> convertToObservable(Class<?> sourceType) {
     return returnTypeSupport.convertToObservable(sourceType);
   }
 
@@ -136,7 +136,7 @@ public class HalApiTypeSupportAdapter implements HalApiTypeSupport {
     }
 
     @Override
-    public Function<? super Object, Observable<?>> convertToObservable(Class<?> sourceType) {
+    public Function<Object, Observable<Object>> convertToObservable(Class<?> sourceType) {
       return null;
     }
 

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/reflection/RxJavaReflectionUtils.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/reflection/RxJavaReflectionUtils.java
@@ -61,7 +61,7 @@ public final class RxJavaReflectionUtils {
    * @return an {@link Observable} that emits the items from the reactive stream returned by the method
    */
   @SuppressWarnings("PMD.PreserveStackTrace")
-  public static Observable<?> invokeMethodAndReturnObservable(Object resourceImplInstance, Method method, RequestMetricsCollector metrics,
+  public static Observable<Object> invokeMethodAndReturnObservable(Object resourceImplInstance, Method method, RequestMetricsCollector metrics,
       HalApiTypeSupport typeSupport) {
 
     String fullMethodName = HalApiReflectionUtils.getClassAndMethodName(resourceImplInstance, method, typeSupport);
@@ -103,7 +103,7 @@ public final class RxJavaReflectionUtils {
 
     ParameterizedType observableType = (ParameterizedType)returnType;
 
-    Function<Object, Observable<?>> conversion = typeSupport.convertToObservable(method.getReturnType());
+    Function<Object, Observable<Object>> conversion = typeSupport.convertToObservable(method.getReturnType());
 
     if (conversion == null) {
       throw new HalApiDeveloperException("The return type " + method.getReturnType().getSimpleName()
@@ -128,14 +128,14 @@ public final class RxJavaReflectionUtils {
    * @return an instance of the target type that will replay (and cache!) the items emitted by the given reactive
    *         instance
    */
-  public static Observable<?> convertAndCacheReactiveType(Object reactiveInstance, Class<?> targetType, RequestMetricsCollector metrics,
+  public static Observable<Object> convertAndCacheReactiveType(Object reactiveInstance, Class<?> targetType, RequestMetricsCollector metrics,
       Supplier<String> description, HalApiReturnTypeSupport typeSupport) {
 
-    Observable<?> observable = convertToObservable(reactiveInstance, typeSupport)
+    Observable<Object> observable = convertToObservable(reactiveInstance, typeSupport)
         .compose(EmissionStopwatch.collectMetrics(description, metrics));
 
     // do not use Observable#cache() here, because we want consumers to be able to use Observable#retry()
-    Observable<?> cached = observable.compose(RxJavaTransformers.cacheIfCompleted());
+    Observable<Object> cached = observable.compose(RxJavaTransformers.cacheIfCompleted());
 
     return cached;
   }
@@ -159,11 +159,11 @@ public final class RxJavaReflectionUtils {
     return conversion.apply(observable);
   }
 
-  private static Observable<?> convertToObservable(Object reactiveInstance, HalApiReturnTypeSupport typeSupport) {
+  private static Observable<Object> convertToObservable(Object reactiveInstance, HalApiReturnTypeSupport typeSupport) {
 
     Preconditions.checkNotNull(reactiveInstance, "Cannot convert null objects");
 
-    Function<Object, Observable<?>> conversion = typeSupport.convertToObservable(reactiveInstance.getClass());
+    Function<Object, Observable<Object>> conversion = typeSupport.convertToObservable(reactiveInstance.getClass());
     if (conversion == null) {
       throw new HalApiDeveloperException("The given instance of " + reactiveInstance.getClass().getName() + " is not a supported return type");
     }

--- a/core/src/test/java/io/wcm/caravan/rhyme/api/spi/HalApiReturnTypeSupportTest.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/api/spi/HalApiReturnTypeSupportTest.java
@@ -42,7 +42,7 @@ public class HalApiReturnTypeSupportTest {
       }
 
       @Override
-      public Function<? super Object, Observable<?>> convertToObservable(Class<?> sourceType) {
+      public Function<Object, Observable<Object>> convertToObservable(Class<?> sourceType) {
         return null;
       }
 

--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/RhymeBuilderImplTest.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/RhymeBuilderImplTest.java
@@ -268,7 +268,7 @@ public class RhymeBuilderImplTest {
 
     @SuppressWarnings("unchecked")
     @Override
-    public Function<? super Object, Observable<?>> convertToObservable(Class<?> sourceType) {
+    public Function<Object, Observable<Object>> convertToObservable(Class<?> sourceType) {
       if (Set.class.isAssignableFrom(sourceType)) {
         return o -> Observable.fromIterable((Set)o);
       }

--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/client/ErrorHandlingTest.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/client/ErrorHandlingTest.java
@@ -195,7 +195,7 @@ public class ErrorHandlingTest {
     HalApiReturnTypeSupport typeSupport = new HalApiReturnTypeSupport() {
 
       @Override
-      public Function<? super Object, Observable<?>> convertToObservable(Class<?> sourceType) {
+      public Function<Object, Observable<Object>> convertToObservable(Class<?> sourceType) {
         return (returnValue) -> {
           throw cause;
         };

--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/reflection/CompositeHalApiTypeSupportTest.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/reflection/CompositeHalApiTypeSupportTest.java
@@ -258,7 +258,7 @@ public class CompositeHalApiTypeSupportTest {
   void convertToObservable_should_return_first_non_null_value() throws Exception {
 
     @SuppressWarnings("unchecked")
-    Function<Object, Observable<?>> fun = o -> Observable.fromIterable(() -> ((List)o).iterator());
+    Function<Object, Observable<Object>> fun = o -> Observable.fromIterable(() -> ((List)o).iterator());
     assertThatCompositeReturnsFirstNonNullValueOfReturnTypeMock(a -> a.convertToObservable(Iterator.class), fun);
   }
 


### PR DESCRIPTION
SonarCloud rightfully complained that the `HalApiReturnTypeSupport` interface contained some unnecessary wildcards:

```Function<? super Object, Observable<?>> convertToObservable(Class<?> sourceType);```

This PR simplifies this to
```Function<Object, Observable<Object>> convertToObservable(Class<?> sourceType);```

The change is binary compatible at runtime due to type erasure.

Only if you are implementing your own HalApiReturnTypeSupport, you may see a build error after upgrading the compile time dependency and need to adjust your signature accordingly