### PR TITLE
Improved consistency for handling of null values for link template variables:

### DIFF
--- a/api-interfaces/src/main/java/io/wcm/caravan/rhyme/api/annotations/Related.java
+++ b/api-interfaces/src/main/java/io/wcm/caravan/rhyme/api/annotations/Related.java
@@ -29,6 +29,7 @@ import java.util.stream.Stream;
 
 import io.wcm.caravan.hal.resource.Link;
 import io.wcm.caravan.rhyme.api.relations.StandardRelations;
+import io.wcm.caravan.rhyme.api.resources.LinkableResource;
 
 /**
  * Used to declare methods which defines a link relation and the expected type for linked or embedded resources.
@@ -47,6 +48,13 @@ import io.wcm.caravan.rhyme.api.relations.StandardRelations;
  * Methods with this annotation can have parameters with {@link TemplateVariable} or
  * {@link TemplateVariables} annotations to define URI templates that clients can expand with the values
  * specified in those parameters.
+ * </p>
+ * <p>
+ * If any of these parameters are invoked with null values, the link template will be only partially expanded
+ * and you can access the partially expanded template by calling {@link LinkableResource#createLink()} on the returned
+ * proxies.
+ * The proxy will still fully resolve the link template (by stripping variables with null values) before
+ * fetching the resource (if you call any other method on the proxy that requires the resource to be loaded)
  * </p>
  * <p>
  * On the server side, these methods will be called by the framework when the resource is rendered. Any parameters for

--- a/core/changes.xml
+++ b/core/changes.xml
@@ -24,7 +24,12 @@
   <body>
 
     <release version="1.1.2" date="not released">
-      <action type="update" dev="ssauder">
+      <action type="add" dev="ssauder">
+        Improved consistency for handling of null values for link template variables: when calling #createLink on a client proxy you'll always
+        get the link template (which may be partially expanded if some values were not null in the invocation).
+        When following such links, the template will be fully resolved before loading the target resource.
+      </action>
+      <action type="fix" dev="ssauder">
         Improved reliability when parsing max-age response header.
       </action>
      <action type="update" dev="ssauder">

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/HalApiClientProxyFactory.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/HalApiClientProxyFactory.java
@@ -130,9 +130,9 @@ public final class HalApiClientProxyFactory {
       return createProxy(relatedResourceType, rxHal, null);
     }
 
-    // the same proxy instance can be re-used when the link is pointing to the resource, and the proxy type are the same.
-    // it's important to consider the full link for the cache key, because different links can point to the same URL,
-    // but callers of createLink should receive exactly the same link that were followed to create the proxy.
+    // the same proxy instance can be re-used when the link is pointing to the same resource, and the interface type to proxy are the same.
+    // it's important to consider the full link for the cache key, because differently named links can point to the same URL,
+    // but callers of createLink should receive exactly the same link instance that was followed to create the proxy.
     String cacheKey = linkToResource.getModel().toString() + relatedResourceType.getName();
 
     try {

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/HalApiInvocationHandler.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/HalApiInvocationHandler.java
@@ -20,6 +20,8 @@
 
 package io.wcm.caravan.rhyme.impl.client.proxy;
 
+import static io.wcm.caravan.rhyme.impl.reflection.RxJavaReflectionUtils.convertObservableTo;
+
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.util.NoSuchElementException;
@@ -42,7 +44,6 @@ import io.wcm.caravan.rhyme.api.exceptions.HalApiClientException;
 import io.wcm.caravan.rhyme.api.exceptions.HalApiDeveloperException;
 import io.wcm.caravan.rhyme.impl.metadata.EmissionStopwatch;
 import io.wcm.caravan.rhyme.impl.reflection.HalApiTypeSupport;
-import io.wcm.caravan.rhyme.impl.reflection.RxJavaReflectionUtils;
 import io.wcm.caravan.rhyme.impl.util.RxJavaTransformers;
 
 /**
@@ -88,7 +89,7 @@ final class HalApiInvocationHandler implements InvocationHandler {
 
       Observable<Object> rxReturnValue = getCachingObservableReturnValue(invocation);
 
-      return RxJavaReflectionUtils.convertObservableTo(rxReturnValue, method.getReturnType(), typeSupport);
+      return convertObservableTo(method.getReturnType(), rxReturnValue, typeSupport);
     }
     // CHECKSTYLE:OFF
     catch (HalApiDeveloperException | HalApiClientException ex) {

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/HalApiInvocationHandler.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/HalApiInvocationHandler.java
@@ -24,13 +24,13 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.util.NoSuchElementException;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 
-import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.core.Single;
 import io.wcm.caravan.hal.resource.HalResource;
@@ -40,20 +40,22 @@ import io.wcm.caravan.rhyme.api.common.RequestMetricsCollector;
 import io.wcm.caravan.rhyme.api.common.RequestMetricsStopwatch;
 import io.wcm.caravan.rhyme.api.exceptions.HalApiClientException;
 import io.wcm.caravan.rhyme.api.exceptions.HalApiDeveloperException;
+import io.wcm.caravan.rhyme.impl.metadata.EmissionStopwatch;
 import io.wcm.caravan.rhyme.impl.reflection.HalApiTypeSupport;
 import io.wcm.caravan.rhyme.impl.reflection.RxJavaReflectionUtils;
+import io.wcm.caravan.rhyme.impl.util.RxJavaTransformers;
 
 /**
  * Handles calls to proxy methods from dynamic proxies created with {@link HalApiClientProxyFactory}
  */
 final class HalApiInvocationHandler implements InvocationHandler {
 
-
   private final Cache<String, Observable<Object>> returnValueCache = CacheBuilder.newBuilder().build();
 
   private final Single<HalResource> rxResource;
   private final Class resourceInterface;
   private final Link linkToResource;
+
   private final HalApiClientProxyFactory proxyFactory;
   private final RequestMetricsCollector metrics;
   private final HalApiTypeSupport typeSupport;
@@ -83,30 +85,32 @@ final class HalApiInvocationHandler implements InvocationHandler {
 
     // collect the time spend calling all proxy methods during the current request in the HalResponseMetadata object
     try (RequestMetricsStopwatch sw = metrics.startStopwatch(HalApiClient.class, () -> "calling " + invocation)) {
-      Observable<Object> rxReturnValue = getCachedObservableReturnValue(invocation);
+
+      Observable<Object> rxReturnValue = getCachingObservableReturnValue(invocation);
+
       return RxJavaReflectionUtils.convertObservableTo(rxReturnValue, method.getReturnType(), typeSupport);
     }
     // CHECKSTYLE:OFF
     catch (HalApiDeveloperException | HalApiClientException ex) {
-      // these exceptions should just be re-thrown as they are implementation errors by the developer
-      // (e.g. using invalid types in the signatures of the HAL API interface),
-      //or contain important context information from failed HTTP request
+      // these exceptions should just be re-thrown as they are either implementation errors by the developer
+      // (e.g. using invalid types in the signatures of the HAL API interface), or client errors
+      // which both already contain important context information
       throw ex;
     }
     // CHECKSTYLE:ON
     catch (NoSuchElementException ex) {
       // these exceptions should be re-thrown with a better error message
       throw new HalApiDeveloperException("The invocation of " + invocation + " has failed, "
-          + "most likely because no link or embedded resource with appropriate relation was found in the HAL resource", ex);
+          + "most likely because no link or embedded resource with the appropriate relation was found in the HAL resource", ex);
     }
     // CHECKSTYLE:OFF - we really want to catch any other possible runtime exceptions here to add additional information on the method being called
     catch (Exception e) {
       // CHECKSTYLE:ON
-      throw new RuntimeException("The invocation of " + invocation + " on a client proxy has failed with an unexpected exception", e);
+      throw new HalApiDeveloperException("The invocation of " + invocation + " on a client proxy has failed with an unexpected exception", e);
     }
   }
 
-  private Observable<Object> getCachedObservableReturnValue(HalApiMethodInvocation invocation) throws ExecutionException {
+  private Observable<Object> getCachingObservableReturnValue(HalApiMethodInvocation invocation) throws ExecutionException {
     try {
       return returnValueCache.get(invocation.getCacheKey(), () -> callAnnotationSpecificHandler(invocation));
     }
@@ -115,46 +119,9 @@ final class HalApiInvocationHandler implements InvocationHandler {
     }
   }
 
-  private Single<HalResource> addContextToHalApiClientException(Throwable ex, HalApiMethodInvocation invocation) {
-    if (ex instanceof HalApiClientException) {
-      String msg = "Failed to load an upstream resource that was requested by calling " + invocation;
-      return Single.error(new HalApiClientException(msg, (HalApiClientException)ex));
-    }
-    return Single.error(ex);
-  }
-
-  @SuppressWarnings("PMD.AvoidRethrowingException")
   private Observable<Object> callAnnotationSpecificHandler(HalApiMethodInvocation invocation) {
 
-    if (invocation.isForMethodAnnotatedWithResourceState()) {
-
-      Maybe<Object> state = rxResource
-          .onErrorResumeNext(ex -> addContextToHalApiClientException(ex, invocation))
-          .map(hal -> new ResourceStateHandler(hal, typeSupport, objectMapper))
-          .flatMapMaybe(handler -> handler.handleMethodInvocation(invocation));
-
-      return RxJavaReflectionUtils.convertAndCacheReactiveType(state, invocation.getReturnType(), metrics, invocation::getDescription, typeSupport);
-    }
-
-    if (invocation.isForMethodAnnotatedWithResourceProperties()) {
-
-      Observable<Object> property = rxResource
-          .onErrorResumeNext(ex -> addContextToHalApiClientException(ex, invocation))
-          .map(hal -> new ResourcePropertyHandler(hal, typeSupport, objectMapper))
-          .flatMapObservable(handler -> handler.handleMethodInvocation(invocation));
-
-      return RxJavaReflectionUtils.convertAndCacheReactiveType(property, invocation.getReturnType(), metrics, invocation::getDescription, typeSupport);
-    }
-
-    if (invocation.isForMethodAnnotatedWithRelatedResource()) {
-
-      Observable<Object> relatedProxies = rxResource
-          .onErrorResumeNext(ex -> addContextToHalApiClientException(ex, invocation))
-          .map(hal -> new RelatedResourceHandler(hal, proxyFactory, typeSupport))
-          .flatMapObservable(handler -> handler.handleMethodInvocation(invocation));
-
-      return RxJavaReflectionUtils.convertAndCacheReactiveType(relatedProxies, invocation.getReturnType(), metrics, invocation::getDescription, typeSupport);
-    }
+    // first handle the calls for methods that don't need the HAL resource to be loaded
 
     if (invocation.isForMethodAnnotatedWithResourceLink()) {
 
@@ -162,22 +129,60 @@ final class HalApiInvocationHandler implements InvocationHandler {
       return Observable.just(handler.handleMethodInvocation(invocation));
     }
 
-    if (invocation.isForMethodAnnotatedWithResourceRepresentation()) {
-
-      Single<Object> representation = rxResource
-          .onErrorResumeNext(ex -> addContextToHalApiClientException(ex, invocation))
-          .map(hal -> new ResourceRepresentationHandler(hal))
-          .flatMap(handler -> handler.handleMethodInvocation(invocation));
-
-      return RxJavaReflectionUtils.convertAndCacheReactiveType(representation, invocation.getReturnType(), metrics, invocation::getDescription, typeSupport);
-    }
-
     if (invocation.toString().endsWith("#toString()")) {
+
       String linkDesc = linkToResource != null ? " at " + linkToResource.getHref() : " (embedded without self link)";
       return Observable.just("dynamic client proxy for " + invocation.getResourceInterfaceName() + linkDesc);
     }
 
+    // create the right handler depending on the annotation on the method
+    Function<HalResource, Observable<Object>> handler = createAnnotationSpecificHandler(invocation);
+
+    // load the resource
+    return rxResource
+        // once it's loaded, create the method's return value as an Observable
+        .flatMapObservable(handler::apply)
+        // add context information if the client failed to load the resource
+        .onErrorResumeNext(ex -> addContextToHalApiClientException(ex, invocation))
+        // measure the time it takes for all this to complete
+        .compose(EmissionStopwatch.collectMetrics(invocation::getDescription, metrics))
+        // ensure that the Observable can be replayed if there are multiple invocations of the same proxy method,
+        // but not use Observable#cache() here, because we want consumers to be able to use Observable#retry()
+        .compose(RxJavaTransformers.cacheIfCompleted());
+  }
+
+  private Function<HalResource, Observable<Object>> createAnnotationSpecificHandler(HalApiMethodInvocation invocation) {
+
+    if (invocation.isForMethodAnnotatedWithResourceState()) {
+
+      return new ResourceStateHandler(invocation, typeSupport, objectMapper);
+    }
+
+    if (invocation.isForMethodAnnotatedWithResourceProperties()) {
+
+      return new ResourcePropertyHandler(invocation, typeSupport, objectMapper);
+    }
+
+    if (invocation.isForMethodAnnotatedWithRelatedResource()) {
+
+      return new RelatedResourceHandler(invocation, typeSupport, proxyFactory);
+    }
+
+    if (invocation.isForMethodAnnotatedWithResourceRepresentation()) {
+
+      return new ResourceRepresentationHandler(invocation);
+    }
+
     // unsupported operation
     throw new HalApiDeveloperException("The method " + invocation + " is not annotated with one of the supported HAL API annotations");
+  }
+
+  private Observable<HalResource> addContextToHalApiClientException(Throwable ex, HalApiMethodInvocation invocation) {
+
+    if (ex instanceof HalApiClientException) {
+      String msg = "Failed to load an upstream resource that was requested by calling " + invocation;
+      return Observable.error(new HalApiClientException(msg, (HalApiClientException)ex));
+    }
+    return Observable.error(ex);
   }
 }

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/RelatedResourceHandler.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/RelatedResourceHandler.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -41,21 +42,22 @@ import io.wcm.caravan.rhyme.api.exceptions.HalApiDeveloperException;
 import io.wcm.caravan.rhyme.api.spi.HalApiAnnotationSupport;
 import io.wcm.caravan.rhyme.impl.reflection.HalApiReflectionUtils;
 
-class RelatedResourceHandler {
+class RelatedResourceHandler implements Function<HalResource, Observable<Object>> {
 
   private static final Logger log = LoggerFactory.getLogger(HalApiInvocationHandler.class);
 
-  private final HalResource contextResource;
+  private final HalApiMethodInvocation invocation;
   private final HalApiClientProxyFactory proxyFactory;
   private final HalApiAnnotationSupport annotationSupport;
 
-  RelatedResourceHandler(HalResource contextResource, HalApiClientProxyFactory proxyFactory, HalApiAnnotationSupport annotationSupport) {
-    this.contextResource = contextResource;
+  RelatedResourceHandler(HalApiMethodInvocation invocation, HalApiAnnotationSupport annotationSupport, HalApiClientProxyFactory proxyFactory) {
+    this.invocation = invocation;
     this.proxyFactory = proxyFactory;
     this.annotationSupport = annotationSupport;
   }
 
-  Observable<Object> handleMethodInvocation(HalApiMethodInvocation invocation) {
+  @Override
+  public Observable<Object> apply(HalResource contextResource) {
 
     // check which relation should be followed and what type of objects the Observable emits
     String relation = invocation.getRelation();

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/ResourceLinkHandler.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/ResourceLinkHandler.java
@@ -32,6 +32,7 @@ class ResourceLinkHandler {
   }
 
   Object handleMethodInvocation(HalApiMethodInvocation invocation) {
+
     Class<?> returnType = invocation.getReturnType();
 
     if (returnType.isAssignableFrom(Link.class)) {
@@ -49,6 +50,6 @@ class ResourceLinkHandler {
     }
 
     throw new HalApiDeveloperException(
-        "the method " + invocation + " annotated with @" + ResourceLink.class.getSimpleName() + " must return either a String or " + Link.class.getName());
+        "The method " + invocation + " annotated with @" + ResourceLink.class.getSimpleName() + " must return either a String or " + Link.class.getName());
   }
 }

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/ResourceRepresentationHandler.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/ResourceRepresentationHandler.java
@@ -19,36 +19,39 @@
  */
 package io.wcm.caravan.rhyme.impl.client.proxy;
 
+import java.util.function.Function;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
-import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.core.Observable;
 import io.wcm.caravan.hal.resource.HalResource;
 import io.wcm.caravan.rhyme.api.annotations.ResourceRepresentation;
 import io.wcm.caravan.rhyme.api.exceptions.HalApiDeveloperException;
 
-class ResourceRepresentationHandler {
+class ResourceRepresentationHandler implements Function<HalResource, Observable<Object>> {
 
-  private final HalResource resource;
+  private final HalApiMethodInvocation invocation;
 
-  ResourceRepresentationHandler(HalResource resource) {
-    this.resource = resource;
+  ResourceRepresentationHandler(HalApiMethodInvocation invocation) {
+    this.invocation = invocation;
   }
 
-  Single<Object> handleMethodInvocation(HalApiMethodInvocation invocation) {
+  @Override
+  public Observable<Object> apply(HalResource resource) {
 
     Class<?> emissionType = invocation.getEmissionType();
 
     if (emissionType.isAssignableFrom(HalResource.class)) {
-      return Single.just(resource);
+      return Observable.just(resource);
     }
 
     if (emissionType.isAssignableFrom(ObjectNode.class)) {
-      return Single.just(resource.getModel());
+      return Observable.just(resource.getModel());
     }
 
     if (emissionType.isAssignableFrom(String.class)) {
-      return Single.just(resource.getModel().toString());
+      return Observable.just(resource.getModel().toString());
     }
 
     throw new HalApiDeveloperException(

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/ResourceStateHandler.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/ResourceStateHandler.java
@@ -32,7 +32,7 @@ import io.wcm.caravan.rhyme.impl.reflection.HalApiTypeSupport;
 
 class ResourceStateHandler implements Function<HalResource, Observable<Object>> {
 
-  private static final Logger log = LoggerFactory.getLogger(HalApiInvocationHandler.class);
+  private static final Logger log = LoggerFactory.getLogger(ResourceStateHandler.class);
 
   private final HalApiMethodInvocation invocation;
   private final HalApiTypeSupport typeSupport;

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/reflection/RxJavaReflectionUtils.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/reflection/RxJavaReflectionUtils.java
@@ -118,12 +118,12 @@ public final class RxJavaReflectionUtils {
 
   /**
    * Converts the observable into any other type supported by the given {@link HalApiTypeSupport} instance
+   * @param targetType to which the observable should be converted
    * @param observable to convert
-   * @param targetType to which the observable should be convert
    * @param typeSupport provides the available conversion functions
    * @return an object of the given target type
    */
-  public static Object convertObservableTo(Observable<?> observable, Class<?> targetType, HalApiReturnTypeSupport typeSupport) {
+  public static Object convertObservableTo(Class<?> targetType, Observable<?> observable, HalApiReturnTypeSupport typeSupport) {
 
     Preconditions.checkNotNull(targetType, "A target type must be provided");
 

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/reflection/RxJavaReflectionUtils.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/reflection/RxJavaReflectionUtils.java
@@ -24,7 +24,6 @@ import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 import org.reactivestreams.Publisher;
 
@@ -40,8 +39,6 @@ import io.wcm.caravan.rhyme.api.exceptions.HalApiDeveloperException;
 import io.wcm.caravan.rhyme.api.exceptions.HalApiServerException;
 import io.wcm.caravan.rhyme.api.server.AsyncHalResponseRenderer;
 import io.wcm.caravan.rhyme.api.spi.HalApiReturnTypeSupport;
-import io.wcm.caravan.rhyme.impl.metadata.EmissionStopwatch;
-import io.wcm.caravan.rhyme.impl.util.RxJavaTransformers;
 
 /**
  * Internal utility methods to invoke methods returning reactive streams, and converting between various
@@ -117,27 +114,6 @@ public final class RxJavaReflectionUtils {
         "return types must be generic class with Class type parameters (e.g. List<ObjectNode>), but found " + resourceType.getTypeName());
 
     return (Class)resourceType;
-  }
-
-  /**
-   * @param reactiveInstance a {@link Single}, {@link Maybe}, {@link Observable} or {@link Publisher}
-   * @param targetType {@link Single}, {@link Maybe}, {@link Observable} or {@link Publisher} class
-   * @param metrics to collect emission times
-   * @param description for the metrics
-   * @param typeSupport the strategy to perform type conversions of return values
-   * @return an instance of the target type that will replay (and cache!) the items emitted by the given reactive
-   *         instance
-   */
-  public static Observable<Object> convertAndCacheReactiveType(Object reactiveInstance, Class<?> targetType, RequestMetricsCollector metrics,
-      Supplier<String> description, HalApiReturnTypeSupport typeSupport) {
-
-    Observable<Object> observable = convertToObservable(reactiveInstance, typeSupport)
-        .compose(EmissionStopwatch.collectMetrics(description, metrics));
-
-    // do not use Observable#cache() here, because we want consumers to be able to use Observable#retry()
-    Observable<Object> cached = observable.compose(RxJavaTransformers.cacheIfCompleted());
-
-    return cached;
   }
 
   /**

--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/client/RelatedResourceTest.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/client/RelatedResourceTest.java
@@ -23,7 +23,7 @@ import static io.wcm.caravan.rhyme.api.relations.StandardRelations.ALTERNATE;
 import static io.wcm.caravan.rhyme.api.relations.StandardRelations.ITEM;
 import static io.wcm.caravan.rhyme.api.relations.StandardRelations.SECTION;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -69,8 +69,11 @@ public class RelatedResourceTest {
         .flatMap(ResourceWithSingleState::getProperties)
         .blockingGet();
 
-    assertThat(linkedState).isNotNull();
-    assertThat(linkedState.text).isEqualTo("item text");
+    assertThat(linkedState)
+        .isNotNull();
+
+    assertThat(linkedState.text)
+        .isEqualTo("item text");
   }
 
   @Test
@@ -78,10 +81,11 @@ public class RelatedResourceTest {
 
     entryPoint.createLinked(ALTERNATE).setText("item text");
 
-    Throwable ex = catchThrowable(
+    Throwable ex = assertThrows(NoSuchElementException.class,
         () -> client.createProxy(ResourceWithSingleRelated.class).getItem().blockingGet());
 
-    assertThat(ex).isInstanceOf(NoSuchElementException.class);
+    assertThat(ex)
+        .hasMessage(null);
   }
 
   @Test
@@ -94,8 +98,11 @@ public class RelatedResourceTest {
         .flatMap(ResourceWithSingleState::getProperties)
         .blockingGet();
 
-    assertThat(linkedState).isNotNull();
-    assertThat(linkedState.text).isEqualTo("item text");
+    assertThat(linkedState)
+        .isNotNull();
+
+    assertThat(linkedState.text)
+        .isEqualTo("item text");
   }
 
   @Test
@@ -103,10 +110,11 @@ public class RelatedResourceTest {
 
     entryPoint.createEmbedded(ALTERNATE).setText("item text");
 
-    Throwable ex = catchThrowable(
+    Throwable ex = assertThrows(NoSuchElementException.class,
         () -> client.createProxy(ResourceWithSingleRelated.class).getItem().blockingGet());
 
-    assertThat(ex).isInstanceOf(NoSuchElementException.class);
+    assertThat(ex)
+        .hasMessage(null);
   }
 
 
@@ -127,8 +135,11 @@ public class RelatedResourceTest {
         .flatMapSingle(ResourceWithSingleState::getProperties)
         .blockingGet();
 
-    assertThat(linkedState).isNotNull();
-    assertThat(linkedState.text).isEqualTo("item text");
+    assertThat(linkedState)
+        .isNotNull();
+
+    assertThat(linkedState.text)
+        .isEqualTo("item text");
   }
 
   @Test
@@ -140,7 +151,8 @@ public class RelatedResourceTest {
     Maybe<ResourceWithSingleState> maybeLinked = client.createProxy(ResourceWithOptionalRelated.class)
         .getOptionalItem();
 
-    assertThat(maybeLinked.isEmpty().blockingGet()).isTrue();
+    assertThat(maybeLinked.isEmpty().blockingGet())
+        .isTrue();
   }
 
   @Test
@@ -153,8 +165,11 @@ public class RelatedResourceTest {
         .flatMapSingle(ResourceWithSingleState::getProperties)
         .blockingGet();
 
-    assertThat(linkedState).isNotNull();
-    assertThat(linkedState.text).isEqualTo("item text");
+    assertThat(linkedState)
+        .isNotNull();
+
+    assertThat(linkedState.text)
+        .isEqualTo("item text");
   }
 
   @Test
@@ -166,7 +181,8 @@ public class RelatedResourceTest {
     Maybe<ResourceWithSingleState> maybeEmbedded = client.createProxy(ResourceWithOptionalRelated.class)
         .getOptionalItem();
 
-    assertThat(maybeEmbedded.isEmpty().blockingGet()).isTrue();
+    assertThat(maybeEmbedded.isEmpty().blockingGet())
+        .isTrue();
   }
 
 
@@ -188,8 +204,11 @@ public class RelatedResourceTest {
         .firstOrError()
         .blockingGet();
 
-    assertThat(linkedState).isNotNull();
-    assertThat(linkedState.text).isEqualTo("item text");
+    assertThat(linkedState)
+        .isNotNull();
+
+    assertThat(linkedState.text)
+        .isEqualTo("item text");
   }
 
   @Test
@@ -201,7 +220,8 @@ public class RelatedResourceTest {
     Observable<ResourceWithSingleState> rxLinkedResources = client.createProxy(ResourceWithMultipleRelated.class)
         .getItems();
 
-    assertThat(rxLinkedResources.isEmpty().blockingGet()).isTrue();
+    assertThat(rxLinkedResources.isEmpty().blockingGet())
+        .isTrue();
   }
 
   @Test
@@ -216,9 +236,12 @@ public class RelatedResourceTest {
         .toList()
         .blockingGet();
 
-    assertThat(linkedStates).hasSize(10);
+    assertThat(linkedStates)
+        .hasSize(10);
+
     for (int i = 0; i < numItems; i++) {
-      assertThat(linkedStates.get(i).number).isEqualTo(i);
+      assertThat(linkedStates.get(i).number)
+          .isEqualTo(i);
     }
   }
 
@@ -233,8 +256,11 @@ public class RelatedResourceTest {
         .firstOrError()
         .blockingGet();
 
-    assertThat(embeddedState).isNotNull();
-    assertThat(embeddedState.text).isEqualTo("item text");
+    assertThat(embeddedState)
+        .isNotNull();
+
+    assertThat(embeddedState.text)
+        .isEqualTo("item text");
   }
 
   @Test
@@ -246,7 +272,8 @@ public class RelatedResourceTest {
     Observable<ResourceWithSingleState> rxEmbeddedResources = client.createProxy(ResourceWithMultipleRelated.class)
         .getItems();
 
-    assertThat(rxEmbeddedResources.isEmpty().blockingGet()).isTrue();
+    assertThat(rxEmbeddedResources.isEmpty().blockingGet())
+        .isTrue();
   }
 
   @Test
@@ -261,9 +288,12 @@ public class RelatedResourceTest {
         .toList()
         .blockingGet();
 
-    assertThat(embeddedStates).hasSize(10);
+    assertThat(embeddedStates)
+        .hasSize(10);
+
     for (int i = 0; i < numItems; i++) {
-      assertThat(embeddedStates.get(i).number).isEqualTo(i);
+      assertThat(embeddedStates.get(i).number)
+          .isEqualTo(i);
     }
   }
 
@@ -282,9 +312,12 @@ public class RelatedResourceTest {
         .toList()
         .blockingGet();
 
-    assertThat(embeddedStates).hasSize(10);
+    assertThat(embeddedStates)
+        .hasSize(10);
+
     for (int i = 0; i < numItems; i++) {
-      assertThat(embeddedStates.get(i).number).isEqualTo(i);
+      assertThat(embeddedStates.get(i).number)
+          .isEqualTo(i);
     }
   }
 
@@ -307,8 +340,11 @@ public class RelatedResourceTest {
         .firstOrError()
         .blockingGet();
 
-    assertThat(linkedState).isNotNull();
-    assertThat(linkedState.text).isEqualTo("item text");
+    assertThat(linkedState)
+        .isNotNull();
+
+    assertThat(linkedState.text)
+        .isEqualTo("item text");
   }
 
   interface ResourceWithoutAnnotation {
@@ -350,29 +386,32 @@ public class RelatedResourceTest {
   @Test
   void should_throw_developer_exception_if_annotation_is_missing_on_proxy_method() {
 
-    Throwable ex = catchThrowable(
+    Throwable ex = assertThrows(HalApiDeveloperException.class,
         () -> client.createProxy(ResourceWithIllegalAnnotations.class).noAnnotation());
 
-    assertThat(ex).isInstanceOf(HalApiDeveloperException.class).hasMessageContaining("is not annotated with one of the supported HAL API annotations");
+    assertThat(ex)
+        .hasMessageContaining("is not annotated with one of the supported HAL API annotations");
   }
 
   @Test
   void should_throw_developer_exception_if_annotation_is_missing_on_related_resource_type() {
 
-    Throwable ex = catchThrowable(
+    Throwable ex = assertThrows(HalApiDeveloperException.class,
         () -> client.createProxy(ResourceWithIllegalAnnotations.class).getInvalidLinked().blockingGet());
 
-    assertThat(ex).isInstanceOf(HalApiDeveloperException.class)
-        .hasMessageContaining("has an invalid emission type").hasMessageEndingWith("which does not have a @HalApiInterface annotation.");
+    assertThat(ex)
+        .hasMessageContaining("has an invalid emission type")
+        .hasMessageEndingWith("which does not have a @HalApiInterface annotation.");
   }
 
   @Test
   void should_throw_developer_exception_if_return_type_does_not_emit_an_interface() {
 
-    Throwable ex = catchThrowable(
+    Throwable ex = assertThrows(HalApiDeveloperException.class,
         () -> client.createProxy(ResourceWithIllegalAnnotations.class).notAnInterface().blockingGet());
 
-    assertThat(ex).isInstanceOf(HalApiDeveloperException.class)
-        .hasMessageContaining("has an invalid emission type").hasMessageEndingWith("which does not have a @HalApiInterface annotation.");
+    assertThat(ex)
+        .hasMessageContaining("has an invalid emission type")
+        .hasMessageEndingWith("which does not have a @HalApiInterface annotation.");
   }
 }

--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/client/RelatedResourceTest.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/client/RelatedResourceTest.java
@@ -81,8 +81,9 @@ public class RelatedResourceTest {
 
     entryPoint.createLinked(ALTERNATE).setText("item text");
 
-    Throwable ex = assertThrows(NoSuchElementException.class,
-        () -> client.createProxy(ResourceWithSingleRelated.class).getItem().blockingGet());
+    Single<ResourceWithSingleState> linkedResource = client.createProxy(ResourceWithSingleRelated.class).getItem();
+
+    Throwable ex = assertThrows(NoSuchElementException.class, linkedResource::blockingGet);
 
     assertThat(ex)
         .hasMessage(null);
@@ -110,8 +111,9 @@ public class RelatedResourceTest {
 
     entryPoint.createEmbedded(ALTERNATE).setText("item text");
 
-    Throwable ex = assertThrows(NoSuchElementException.class,
-        () -> client.createProxy(ResourceWithSingleRelated.class).getItem().blockingGet());
+    Single<ResourceWithSingleState> embeddedResource = client.createProxy(ResourceWithSingleRelated.class).getItem();
+
+    Throwable ex = assertThrows(NoSuchElementException.class, embeddedResource::blockingGet);
 
     assertThat(ex)
         .hasMessage(null);
@@ -386,8 +388,9 @@ public class RelatedResourceTest {
   @Test
   void should_throw_developer_exception_if_annotation_is_missing_on_proxy_method() {
 
-    Throwable ex = assertThrows(HalApiDeveloperException.class,
-        () -> client.createProxy(ResourceWithIllegalAnnotations.class).noAnnotation());
+    ResourceWithIllegalAnnotations proxy = client.createProxy(ResourceWithIllegalAnnotations.class);
+
+    Throwable ex = assertThrows(HalApiDeveloperException.class, proxy::noAnnotation);
 
     assertThat(ex)
         .hasMessageContaining("is not annotated with one of the supported HAL API annotations");
@@ -396,8 +399,11 @@ public class RelatedResourceTest {
   @Test
   void should_throw_developer_exception_if_annotation_is_missing_on_related_resource_type() {
 
-    Throwable ex = assertThrows(HalApiDeveloperException.class,
-        () -> client.createProxy(ResourceWithIllegalAnnotations.class).getInvalidLinked().blockingGet());
+    ResourceWithIllegalAnnotations proxy = client.createProxy(ResourceWithIllegalAnnotations.class);
+
+    Single<ResourceWithoutAnnotation> resource = proxy.getInvalidLinked();
+
+    Throwable ex = assertThrows(HalApiDeveloperException.class, resource::blockingGet);
 
     assertThat(ex)
         .hasMessageContaining("has an invalid emission type")
@@ -407,8 +413,11 @@ public class RelatedResourceTest {
   @Test
   void should_throw_developer_exception_if_return_type_does_not_emit_an_interface() {
 
-    Throwable ex = assertThrows(HalApiDeveloperException.class,
-        () -> client.createProxy(ResourceWithIllegalAnnotations.class).notAnInterface().blockingGet());
+    ResourceWithIllegalAnnotations proxy = client.createProxy(ResourceWithIllegalAnnotations.class);
+
+    Single<TestState> returnValue = proxy.notAnInterface();
+
+    Throwable ex = assertThrows(HalApiDeveloperException.class, returnValue::blockingGet);
 
     assertThat(ex)
         .hasMessageContaining("has an invalid emission type")

--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/client/ResourceLinkTest.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/client/ResourceLinkTest.java
@@ -255,7 +255,7 @@ public class ResourceLinkTest {
   }
 
   @Test
-  void link_template_should_be_fully_expanded_if_at_least_one_parameter_is_null() {
+  void link_template_should_be_partially_expanded_if_at_least_one_parameter_is_null() {
 
     String uriTemplate = "/test{?intParam,stringParam,listParam*}";
     entryPoint.asHalResource().addLinks(ITEM, new Link(uriTemplate));
@@ -265,7 +265,7 @@ public class ResourceLinkTest {
         .map(LinkTargetResource::createLink)
         .blockingGet();
 
-    assertThat(link.getHref()).isEqualTo("/test?intParam=5");
+    assertThat(link.getHref()).isEqualTo("/test?intParam=5{&stringParam,listParam*}");
   }
 
   @Test

--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/client/ResourceStateTest.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/client/ResourceStateTest.java
@@ -34,6 +34,7 @@ import io.reactivex.rxjava3.core.Single;
 import io.wcm.caravan.rhyme.api.annotations.HalApiInterface;
 import io.wcm.caravan.rhyme.api.annotations.ResourceState;
 import io.wcm.caravan.rhyme.api.exceptions.HalApiDeveloperException;
+import io.wcm.caravan.rhyme.api.resources.LinkableResource;
 import io.wcm.caravan.rhyme.impl.client.ClientTestSupport.MockClientTestSupport;
 import io.wcm.caravan.rhyme.testing.resources.TestResourceState;
 
@@ -43,7 +44,7 @@ public class ResourceStateTest {
   private final MockClientTestSupport client = ClientTestSupport.withMocking();
 
   @HalApiInterface
-  interface ResourceWithSingleState {
+  interface ResourceWithSingleState extends LinkableResource {
 
     @ResourceState
     Single<TestResourceState> getProperties();

--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/client/blocking/RelatedResourceTest.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/client/blocking/RelatedResourceTest.java
@@ -22,9 +22,10 @@ package io.wcm.caravan.rhyme.impl.client.blocking;
 import static io.wcm.caravan.rhyme.api.relations.StandardRelations.ALTERNATE;
 import static io.wcm.caravan.rhyme.api.relations.StandardRelations.ITEM;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -87,8 +88,11 @@ public class RelatedResourceTest {
         .getItem()
         .getProperties();
 
-    assertThat(linkedState).isNotNull();
-    assertThat(linkedState.text).isEqualTo("item text");
+    assertThat(linkedState)
+        .isNotNull();
+
+    assertThat(linkedState.text)
+        .isEqualTo("item text");
   }
 
   @Test
@@ -96,11 +100,13 @@ public class RelatedResourceTest {
 
     entryPoint.createLinked(ALTERNATE).setText("item text");
 
-    Throwable ex = catchThrowable(
+    Throwable ex = assertThrows(HalApiDeveloperException.class,
         () -> createClientProxy(ResourceWithSingleRelated.class).getItem());
 
-    assertThat(ex).isInstanceOf(HalApiDeveloperException.class).hasMessageStartingWith("The invocation of ResourceWithSingleRelated#getItem() has failed");
-
+    assertThat(ex)
+        .hasMessageStartingWith("The invocation of ResourceWithSingleRelated#getItem() has failed")
+        .hasMessageContaining("no link or embedded resource with the appropriate relation")
+        .hasRootCauseInstanceOf(NoSuchElementException.class);
   }
 
   @Test
@@ -121,8 +127,11 @@ public class RelatedResourceTest {
         .getItem()
         .getProperties();
 
-    assertThat(linkedState).isNotNull();
-    assertThat(linkedState.text).isEqualTo("item text");
+    assertThat(linkedState)
+        .isNotNull();
+
+    assertThat(linkedState.text)
+        .isEqualTo("item text");
   }
 
   @Test
@@ -130,12 +139,14 @@ public class RelatedResourceTest {
 
     entryPoint.createEmbedded(ALTERNATE).setText("item text");
 
-    Throwable ex = catchThrowable(
+    Throwable ex = assertThrows(HalApiDeveloperException.class,
         () -> createClientProxy(ResourceWithSingleRelated.class).getItem().getProperties());
 
-    assertThat(ex).isInstanceOf(HalApiDeveloperException.class).hasMessageStartingWith("The invocation of ResourceWithSingleRelated#getItem() has failed");
+    assertThat(ex)
+        .hasMessageStartingWith("The invocation of ResourceWithSingleRelated#getItem() has failed")
+        .hasMessageContaining("no link or embedded resource with the appropriate relation")
+        .hasRootCauseInstanceOf(NoSuchElementException.class);
   }
-
 
   @HalApiInterface
   interface ResourceWithOptionalRelated {
@@ -154,8 +165,11 @@ public class RelatedResourceTest {
         .map(ResourceWithRequiredState::getProperties)
         .get();
 
-    assertThat(linkedState).isNotNull();
-    assertThat(linkedState.text).isEqualTo("item text");
+    assertThat(linkedState)
+        .isNotNull();
+
+    assertThat(linkedState.text)
+        .isEqualTo("item text");
   }
 
   @Test
@@ -167,7 +181,8 @@ public class RelatedResourceTest {
     Optional<ResourceWithRequiredState> maybeLinked = createClientProxy(ResourceWithOptionalRelated.class)
         .getOptionalItem();
 
-    assertThat(maybeLinked.isPresent()).isFalse();
+    assertThat(maybeLinked.isPresent())
+        .isFalse();
   }
 
   @Test
@@ -180,8 +195,11 @@ public class RelatedResourceTest {
         .map(ResourceWithRequiredState::getProperties)
         .get();
 
-    assertThat(linkedState).isNotNull();
-    assertThat(linkedState.text).isEqualTo("item text");
+    assertThat(linkedState)
+        .isNotNull();
+
+    assertThat(linkedState.text)
+        .isEqualTo("item text");
   }
 
   @Test
@@ -193,7 +211,8 @@ public class RelatedResourceTest {
     Optional<ResourceWithRequiredState> maybeEmbedded = createClientProxy(ResourceWithOptionalRelated.class)
         .getOptionalItem();
 
-    assertThat(maybeEmbedded.isPresent()).isFalse();
+    assertThat(maybeEmbedded.isPresent())
+        .isFalse();
   }
 
 
@@ -214,8 +233,11 @@ public class RelatedResourceTest {
         .map(ResourceWithRequiredState::getProperties)
         .findFirst().orElseThrow(() -> new RuntimeException());
 
-    assertThat(linkedState).isNotNull();
-    assertThat(linkedState.text).isEqualTo("item text");
+    assertThat(linkedState)
+        .isNotNull();
+
+    assertThat(linkedState.text)
+        .isEqualTo("item text");
   }
 
   @Test
@@ -224,10 +246,11 @@ public class RelatedResourceTest {
     // create a link with a different relation then defined in the interface
     entryPoint.createLinked(ALTERNATE).setText("item text");
 
-    List<ResourceWithRequiredState> rxLinkedResources = createClientProxy(ResourceWithMultipleRelated.class)
+    List<ResourceWithRequiredState> linkedResources = createClientProxy(ResourceWithMultipleRelated.class)
         .getItems();
 
-    assertThat(rxLinkedResources).isEmpty();
+    assertThat(linkedResources)
+        .isEmpty();
   }
 
   @Test
@@ -241,9 +264,12 @@ public class RelatedResourceTest {
         .map(ResourceWithRequiredState::getProperties)
         .collect(Collectors.toList());
 
-    assertThat(linkedStates).hasSize(10);
+    assertThat(linkedStates)
+        .hasSize(10);
+
     for (int i = 0; i < numItems; i++) {
-      assertThat(linkedStates.get(i).number).isEqualTo(i);
+      assertThat(linkedStates.get(i).number)
+          .isEqualTo(i);
     }
   }
 
@@ -257,8 +283,11 @@ public class RelatedResourceTest {
         .map(ResourceWithRequiredState::getProperties)
         .findFirst().orElseThrow(() -> new RuntimeException());
 
-    assertThat(embeddedState).isNotNull();
-    assertThat(embeddedState.text).isEqualTo("item text");
+    assertThat(embeddedState)
+        .isNotNull();
+
+    assertThat(embeddedState.text)
+        .isEqualTo("item text");
   }
 
   @Test
@@ -267,10 +296,11 @@ public class RelatedResourceTest {
     // create an embeded resource with a different relation then defined in the interface
     entryPoint.createEmbedded(ALTERNATE).setText("item text");
 
-    List<ResourceWithRequiredState> rxEmbeddedResources = createClientProxy(ResourceWithMultipleRelated.class)
+    List<ResourceWithRequiredState> embeddedResources = createClientProxy(ResourceWithMultipleRelated.class)
         .getItems();
 
-    assertThat(rxEmbeddedResources).isEmpty();
+    assertThat(embeddedResources)
+        .isEmpty();
   }
 
   @Test
@@ -284,9 +314,12 @@ public class RelatedResourceTest {
         .map(ResourceWithRequiredState::getProperties)
         .collect(Collectors.toList());
 
-    assertThat(embeddedStates).hasSize(10);
+    assertThat(embeddedStates)
+        .hasSize(10);
+
     for (int i = 0; i < numItems; i++) {
-      assertThat(embeddedStates.get(i).number).isEqualTo(i);
+      assertThat(embeddedStates.get(i).number)
+          .isEqualTo(i);
     }
   }
 
@@ -304,9 +337,12 @@ public class RelatedResourceTest {
         .map(ResourceWithRequiredState::getProperties)
         .collect(Collectors.toList());
 
-    assertThat(embeddedStates).hasSize(10);
+    assertThat(embeddedStates)
+        .hasSize(10);
+
     for (int i = 0; i < numItems; i++) {
-      assertThat(embeddedStates.get(i).number).isEqualTo(i);
+      assertThat(embeddedStates.get(i).number)
+          .isEqualTo(i);
     }
   }
 
@@ -327,7 +363,8 @@ public class RelatedResourceTest {
         .getItems()
         .collect(Collectors.toList());
 
-    assertThat(embedded).hasSize(numItems);
+    assertThat(embedded)
+        .hasSize(numItems);
   }
 
   @Test
@@ -344,7 +381,8 @@ public class RelatedResourceTest {
     List<ResourceWithRequiredState> embedded2 = resource.getItems()
         .collect(Collectors.toList());
 
-    assertThat(embedded1).containsExactlyElementsOf(embedded2);
+    assertThat(embedded1)
+        .containsExactlyElementsOf(embedded2);
   }
 
   @Test
@@ -355,10 +393,9 @@ public class RelatedResourceTest {
     ResourceWithRequiredState linkedResource = createClientProxy(ResourceWithSingleRelated.class)
         .getItem();
 
-    Throwable ex = catchThrowable(() -> linkedResource.hashCode());
+    Throwable ex = assertThrows(HalApiDeveloperException.class, () -> linkedResource.hashCode());
 
     assertThat(ex)
-        .isInstanceOf(HalApiDeveloperException.class)
         .hasMessageStartingWith("You cannot call hashCode() on dynamic client proxies.");
   }
 }

--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/client/blocking/RelatedResourceTest.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/client/blocking/RelatedResourceTest.java
@@ -100,8 +100,9 @@ public class RelatedResourceTest {
 
     entryPoint.createLinked(ALTERNATE).setText("item text");
 
-    Throwable ex = assertThrows(HalApiDeveloperException.class,
-        () -> createClientProxy(ResourceWithSingleRelated.class).getItem());
+    ResourceWithSingleRelated proxy = createClientProxy(ResourceWithSingleRelated.class);
+
+    Throwable ex = assertThrows(HalApiDeveloperException.class, proxy::getItem);
 
     assertThat(ex)
         .hasMessageStartingWith("The invocation of ResourceWithSingleRelated#getItem() has failed")
@@ -139,8 +140,9 @@ public class RelatedResourceTest {
 
     entryPoint.createEmbedded(ALTERNATE).setText("item text");
 
-    Throwable ex = assertThrows(HalApiDeveloperException.class,
-        () -> createClientProxy(ResourceWithSingleRelated.class).getItem().getProperties());
+    ResourceWithRequiredState embeddedResource = createClientProxy(ResourceWithSingleRelated.class).getItem();
+
+    Throwable ex = assertThrows(HalApiDeveloperException.class, embeddedResource::getProperties);
 
     assertThat(ex)
         .hasMessageStartingWith("The invocation of ResourceWithSingleRelated#getItem() has failed")
@@ -181,8 +183,8 @@ public class RelatedResourceTest {
     Optional<ResourceWithRequiredState> maybeLinked = createClientProxy(ResourceWithOptionalRelated.class)
         .getOptionalItem();
 
-    assertThat(maybeLinked.isPresent())
-        .isFalse();
+    assertThat(maybeLinked)
+        .isPresent();
   }
 
   @Test
@@ -211,8 +213,8 @@ public class RelatedResourceTest {
     Optional<ResourceWithRequiredState> maybeEmbedded = createClientProxy(ResourceWithOptionalRelated.class)
         .getOptionalItem();
 
-    assertThat(maybeEmbedded.isPresent())
-        .isFalse();
+    assertThat(maybeEmbedded)
+        .isPresent();
   }
 
 

--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/client/blocking/RelatedResourceTest.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/client/blocking/RelatedResourceTest.java
@@ -140,9 +140,9 @@ public class RelatedResourceTest {
 
     entryPoint.createEmbedded(ALTERNATE).setText("item text");
 
-    ResourceWithRequiredState embeddedResource = createClientProxy(ResourceWithSingleRelated.class).getItem();
+    ResourceWithSingleRelated proxy = createClientProxy(ResourceWithSingleRelated.class);
 
-    Throwable ex = assertThrows(HalApiDeveloperException.class, embeddedResource::getProperties);
+    Throwable ex = assertThrows(HalApiDeveloperException.class, proxy::getItem);
 
     assertThat(ex)
         .hasMessageStartingWith("The invocation of ResourceWithSingleRelated#getItem() has failed")
@@ -184,7 +184,7 @@ public class RelatedResourceTest {
         .getOptionalItem();
 
     assertThat(maybeLinked)
-        .isPresent();
+        .isEmpty();
   }
 
   @Test
@@ -214,7 +214,7 @@ public class RelatedResourceTest {
         .getOptionalItem();
 
     assertThat(maybeEmbedded)
-        .isPresent();
+        .isEmpty();
   }
 
 

--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/reflection/RxJavaReflectionUtilsTest.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/reflection/RxJavaReflectionUtilsTest.java
@@ -87,7 +87,7 @@ public class RxJavaReflectionUtilsTest {
     Observable<String> obs = Observable.just("foo");
 
     Throwable ex = catchThrowable(
-        () -> RxJavaReflectionUtils.convertObservableTo(obs, Iterator.class, typeSupport));
+        () -> RxJavaReflectionUtils.convertObservableTo(Iterator.class, obs, typeSupport));
 
     assertThat(ex).isInstanceOf(HalApiDeveloperException.class)
         .hasMessage("The given target type of java.util.Iterator is not a supported return type");


### PR DESCRIPTION
Previously you could only access the link template of a related method using template variables when passing null to all arguments, and in that case you couldn't follow the link (even if all parameters are optional)

When calling #createLink on a client proxy you'll now be always ab le to get the link template (which may be partially expanded if some values were not null in the invocation).

When following such links, the template will be fully resolved before loading the target resource.