### PR TITLE
Include code coverage from integration tests in SonarCloud report

### DIFF
--- a/examples/osgi-jaxrs-example-service/pom.xml
+++ b/examples/osgi-jaxrs-example-service/pom.xml
@@ -43,6 +43,10 @@
     <tag>HEAD</tag>
   </scm>
 
+  <properties>
+    <sonar.coverage.jacoco.xmlReportPaths>${maven.multiModuleProjectDirectory}/tooling/coverage/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>io.wcm.caravan</groupId>

--- a/examples/osgi-jaxrs-example-service/pom.xml
+++ b/examples/osgi-jaxrs-example-service/pom.xml
@@ -43,10 +43,6 @@
     <tag>HEAD</tag>
   </scm>
 
-  <properties>
-    <sonar.coverage.jacoco.xmlReportPaths>${maven.multiModuleProjectDirectory}/tooling/coverage/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>io.wcm.caravan</groupId>

--- a/tooling/coverage/pom.xml
+++ b/tooling/coverage/pom.xml
@@ -50,6 +50,16 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>io.wcm.caravan.rhyme.examples.osgi-jaxrs-example-launchpad</artifactId>
+      <version>1-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>io.wcm.caravan.rhyme.examples.osgi-jaxrs-example-service</artifactId>
+      <version>1.0.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>io.wcm.caravan.rhyme.examples.spring-hypermedia</artifactId>
       <version>1-SNAPSHOT</version>
     </dependency>

--- a/tooling/parent/pom.xml
+++ b/tooling/parent/pom.xml
@@ -51,6 +51,7 @@
 
   <properties>
     <site.url.module.prefix>rhyme</site.url.module.prefix>
+    <sonar.coverage.jacoco.xmlReportPaths>${maven.multiModuleProjectDirectory}/tooling/coverage/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
some code (especially for the osgi-jaxrs example) is not covered by tests within the same module, but by integration tests from another module.

Coverage from these tests wasn't picked up by SonarCloud, and this is an attempt to fix that (see https://blog.qaware.de/posts/sonarqube-and-jacoco/)