### PR TITLE
Allow to override remote resource implementations

### DIFF
--- a/core/changes.xml
+++ b/core/changes.xml
@@ -23,7 +23,10 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
-    <release version="1.1.2" date="not released">
+    <release version="1.2.0" date="not released">
+      <action type="add" dev="ssauder">
+        Allow to provide custom mock/stub implementations for remote HAL API interfaces (via #withRemoteResourceOverride in RhymeBuilder and HalApiClientBuilder)
+      </action>
       <action type="add" dev="ssauder">
         Improved consistency for handling of null values for link template variables. When calling #createLink on a client proxy, you'll now always
         get the link template (which may be partially expanded if some values were not null in the invocation).

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -30,7 +30,7 @@
   </parent>
 
   <artifactId>io.wcm.caravan.rhyme.core</artifactId>
-  <version>1.1.1-SNAPSHOT</version>
+  <version>1.2.0-SNAPSHOT</version>
   <packaging>bundle</packaging>
 
   <name>Rhyme - Core Framework</name>

--- a/core/src/main/java/io/wcm/caravan/rhyme/api/RhymeBuilder.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/api/RhymeBuilder.java
@@ -19,12 +19,16 @@
  */
 package io.wcm.caravan.rhyme.api;
 
+import java.util.function.Function;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import io.wcm.caravan.rhyme.api.annotations.HalApiInterface;
 import io.wcm.caravan.rhyme.api.client.HalApiClient;
 import io.wcm.caravan.rhyme.api.common.HalResponse;
+import io.wcm.caravan.rhyme.api.common.RequestMetricsCollector;
 import io.wcm.caravan.rhyme.api.resources.LinkableResource;
 import io.wcm.caravan.rhyme.api.server.RhymeMetadataConfiguration;
 import io.wcm.caravan.rhyme.api.spi.ExceptionStatusAndLoggingStrategy;
@@ -130,6 +134,20 @@ public interface RhymeBuilder {
    * @return this
    */
   RhymeBuilder withObjectMapper(ObjectMapper objectMapper);
+
+  /**
+   * Defines an override that will make {@link Rhyme#getRemoteResource(String, Class)} return a custom
+   * implementation for a specific combination of entry point URI and interface class (rather then the default
+   * dynamic proxy). This can be used to mock/stub remote resources in unit and integration tests, or to delegate
+   * remote resource proxy creation for a specific service to a completely different {@link Rhyme} or
+   * {@link HalApiClient} instance.
+   * @param <T> the {@link HalApiInterface} type
+   * @param entryPointUri the URI for which the override will be used
+   * @param halApiInterface an interface defining the HAL API for that URI
+   * @param factoryFunc a function that will create a proxy, stub or server-side implementation of the given interface
+   * @return this
+   */
+  <T> RhymeBuilder withRemoteResourceOverride(String entryPointUri, Class<T> halApiInterface, Function<RequestMetricsCollector, T> factoryFunc);
 
   /**
    * Create the {@link Rhyme} instance to be used to throughout the lifecycle of an incoming request

--- a/core/src/main/java/io/wcm/caravan/rhyme/api/client/HalApiClientBuilder.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/api/client/HalApiClientBuilder.java
@@ -19,12 +19,15 @@
  */
 package io.wcm.caravan.rhyme.api.client;
 
+import java.util.function.Function;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.wcm.caravan.rhyme.api.Rhyme;
 import io.wcm.caravan.rhyme.api.RhymeBuilder;
+import io.wcm.caravan.rhyme.api.annotations.HalApiInterface;
 import io.wcm.caravan.rhyme.api.common.RequestMetricsCollector;
 import io.wcm.caravan.rhyme.api.spi.HalApiAnnotationSupport;
 import io.wcm.caravan.rhyme.api.spi.HalApiReturnTypeSupport;
@@ -99,6 +102,20 @@ public interface HalApiClientBuilder {
    * @return this
    */
   HalApiClientBuilder withObjectMapper(ObjectMapper objectMapper);
+
+  /**
+   * Defines an override that will make {@link HalApiClient#getRemoteResource(String, Class)} return a custom
+   * implementation for a specific combination of entry point URI and interface class (rather then the default
+   * dynamic proxy). This can be used to mock/stub remote resources in unit and integration tests, or to delegate
+   * remote resource proxy creation for a specific service to a completely different {@link Rhyme} or
+   * {@link HalApiClient} instance.
+   * @param <T> the {@link HalApiInterface} type
+   * @param entryPointUri the URI for which the override will be used
+   * @param halApiInterface an interface defining the HAL API for that URI
+   * @param factoryFunc a function that will create a proxy, stub or server-side implementation of the given interface
+   * @return this
+   */
+  <T> HalApiClientBuilder withRemoteResourceOverride(String entryPointUri, Class<T> halApiInterface, Function<RequestMetricsCollector, T> factoryFunc);
 
   /**
    * @return the new {@link HalApiClient} instance

--- a/core/src/main/java/io/wcm/caravan/rhyme/api/client/package-info.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/api/client/package-info.java
@@ -20,5 +20,5 @@
 /**
  * Interfaces for client-side functionality
  */
-@org.osgi.annotation.versioning.Version("1.1.0")
+@org.osgi.annotation.versioning.Version("1.2.0")
 package io.wcm.caravan.rhyme.api.client;

--- a/core/src/main/java/io/wcm/caravan/rhyme/api/package-info.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/api/package-info.java
@@ -20,5 +20,5 @@
 /**
  * Facade interfaces for the core framework
  */
-@org.osgi.annotation.versioning.Version("1.1.0")
+@org.osgi.annotation.versioning.Version("1.2.0")
 package io.wcm.caravan.rhyme.api;

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/client/HalApiClientImpl.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/client/HalApiClientImpl.java
@@ -67,7 +67,7 @@ public class HalApiClientImpl implements HalApiClient {
 
     // first consider any overrides for this interface and URI that may be defined
     return remoteResourceOverrides.get(halApiInterface, uri, metrics)
-        // ptherwise create a proxy instance that loads the entry point lazily when required by any method call on the proxy
+        // otherwise create a proxy instance that loads the entry point lazily (when required by any method call on the proxy)
         .orElseGet(() -> factory.createProxyFromUrl(halApiInterface, uri));
   }
 

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/client/RemoteResourceOverrides.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/client/RemoteResourceOverrides.java
@@ -1,0 +1,73 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2022 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.caravan.rhyme.impl.client;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+import io.wcm.caravan.rhyme.api.Rhyme;
+import io.wcm.caravan.rhyme.api.annotations.HalApiInterface;
+import io.wcm.caravan.rhyme.api.client.HalApiClient;
+import io.wcm.caravan.rhyme.api.common.RequestMetricsCollector;
+
+/**
+ * Provides alternative implementations of {@link HalApiInterface}s that should be returned when
+ * {@link HalApiClient#getRemoteResource(String, Class)} or {@link Rhyme#getRemoteResource(String, Class)}
+ * is called for a specific entry point URI and interface combination.
+ */
+public class RemoteResourceOverrides {
+
+  private final Map<String, Function<RequestMetricsCollector, ?>> factoryMap = new HashMap<>();
+
+  private String constructKey(Class<?> halApiInterface, String entryPointUrl) {
+
+    return halApiInterface.getName() + "@" + entryPointUrl;
+  }
+
+  /**
+   * Defines an override for a specific combination of entry point URI and interface
+   * @param <T> the {@link HalApiInterface} type
+   * @param entryPointUri the URI for which the override will be used
+   * @param halApiInterface an interface defining the HAL API for that URI
+   * @param factorFunc a function that will return a proxy, stub or server-side implementation of the given interface
+   */
+  public <T> void add(String entryPointUri, Class<T> halApiInterface, Function<RequestMetricsCollector, T> factorFunc) {
+
+    String key = constructKey(halApiInterface, entryPointUri);
+
+    factoryMap.put(key, factorFunc);
+  }
+
+  <T> Optional<T> get(Class<T> halApiInterface, String entryPointUrl, RequestMetricsCollector metrics) {
+
+    String key = constructKey(halApiInterface, entryPointUrl);
+
+    if (!factoryMap.containsKey(key)) {
+      return Optional.empty();
+    }
+
+    @SuppressWarnings("unchecked") // this cast should be safe because the add method ensures that the function type matches the interface
+    Function<RequestMetricsCollector, T> function = (Function<RequestMetricsCollector, T>)factoryMap.get(key);
+
+    return Optional.of(function.apply(metrics));
+  }
+}

--- a/core/src/test/java/io/wcm/caravan/rhyme/testing/TestResource.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/testing/TestResource.java
@@ -31,7 +31,7 @@ public interface TestResource {
   @ResourceState
   default Maybe<TestState> getState() {
     return Maybe.empty();
-  };
+  }
 
   @Related(TestRelations.LINKED)
   default Observable<TestResource> getLinked() {

--- a/examples/aem-hal-browser/content-packages/complete/pom.xml
+++ b/examples/aem-hal-browser/content-packages/complete/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>io.wcm.caravan</groupId>
       <artifactId>io.wcm.caravan.rhyme.core</artifactId>
-      <version>1.1.1-SNAPSHOT</version>
+      <version>1.2.0-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/examples/aem-hal-browser/parent/pom.xml
+++ b/examples/aem-hal-browser/parent/pom.xml
@@ -187,7 +187,7 @@
       <dependency>
         <groupId>.io.wcm.caravan</groupId>
         <artifactId>io.wcm.caravan.rhyme.core</artifactId>
-        <version>1.1.1-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>.io.wcm.caravan</groupId>

--- a/examples/osgi-jaxrs-example-launchpad/pom.xml
+++ b/examples/osgi-jaxrs-example-launchpad/pom.xml
@@ -99,7 +99,7 @@
     <dependency>
       <groupId>io.wcm.caravan</groupId>
       <artifactId>io.wcm.caravan.rhyme.core</artifactId>
-      <version>1.1.1-SNAPSHOT</version>
+      <version>1.2.0-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/integration/aem/pom.xml
+++ b/integration/aem/pom.xml
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>io.wcm.caravan</groupId>
       <artifactId>io.wcm.caravan.rhyme.core</artifactId>
-      <version>1.1.1-SNAPSHOT</version>
+      <version>1.2.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
 

--- a/integration/osgi-jaxrs/pom.xml
+++ b/integration/osgi-jaxrs/pom.xml
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>io.wcm.caravan</groupId>
       <artifactId>io.wcm.caravan.rhyme.core</artifactId>
-      <version>1.1.1-SNAPSHOT</version>
+      <version>1.2.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/integration/spring/pom.xml
+++ b/integration/spring/pom.xml
@@ -105,7 +105,7 @@
     <dependency>
       <groupId>io.wcm.caravan</groupId>
       <artifactId>io.wcm.caravan.rhyme.core</artifactId>
-      <version>1.1.1-SNAPSHOT</version>
+      <version>1.2.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
   

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -73,7 +73,7 @@
     <dependency>
       <groupId>io.wcm.caravan</groupId>
       <artifactId>io.wcm.caravan.rhyme.core</artifactId>
-      <version>1.1.0</version>
+      <version>1.2.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <!-- AssertJ for fluent assertions -->

--- a/tooling/coverage/pom.xml
+++ b/tooling/coverage/pom.xml
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>io.wcm.caravan.rhyme.core</artifactId>
-      <version>1.1.1-SNAPSHOT</version>
+      <version>1.2.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
For unit / integration tests of a class that uses HalApiClientRhyme#getRemoteResource you may want to mock/stub the upstream resources using their HAL API interfaces (instead of using the default dynamic client proxies and having to stub responses with a HalResourceLoader)

This PR adds a #withRemoteResourceOverride method to RhymeBuilder and HalApiClientBuilder, which you can use to have #getRemoteResource return a different mock/stub implementation for a specific URI and HalApiInterface class.