### PR TITLE
Reorder module for successful initial build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,12 +40,6 @@
   <modules>
     <module>api-interfaces</module>
     <module>core</module>
-    <module>examples/aem-hal-browser</module>
-    <module>examples/aws-movie-search</module>
-    <module>examples/osgi-jaxrs-example-launchpad</module>
-    <module>examples/osgi-jaxrs-example-service</module>
-    <module>examples/spring-hello-world</module>
-    <module>examples/spring-hypermedia</module>
     <module>integration/aem</module>
     <module>integration/osgi-jaxrs</module>
     <module>integration/spring</module>    
@@ -53,6 +47,12 @@
     <module>tooling/coverage</module>
     <module>tooling/docs-maven-plugin</module>    
     <module>tooling/parent</module>
+    <module>examples/aem-hal-browser</module>
+    <module>examples/aws-movie-search</module>
+    <module>examples/osgi-jaxrs-example-launchpad</module>
+    <module>examples/osgi-jaxrs-example-service</module>
+    <module>examples/spring-hello-world</module>
+    <module>examples/spring-hypermedia</module>
 
   </modules>
 


### PR DESCRIPTION
I cannot initially build the source without this fix.

To reproduce:
* Clear all `io.wcm.caravan.*` artifacts from local repository:
`rm -r ~/.m2/repository/io/wcm/caravan/`
* Execute build
`./mvn clean install`

This leads to:
```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] Rhyme - Parent 1.1.1-SNAPSHOT ...................... SUCCESS [  1.529 s]
[INFO] Rhyme - API Interfaces and Annotations 1.1.1-SNAPSHOT SUCCESS [  5.898 s]
[INFO] Rhyme - Core Framework 1.2.0-SNAPSHOT .............. SUCCESS [ 10.689 s]
[INFO] Rhyme - AEM Example Parent 1.0.0-SNAPSHOT .......... SUCCESS [  0.787 s]
[INFO] Rhyme - Documentation Maven Plugin 1.0.1-SNAPSHOT .. SUCCESS [  8.816 s]
[INFO] Rhyme - AEM Example Core 1.0.0-SNAPSHOT ............ FAILURE [  1.920 s]
[INFO] Rhyme - Testing Support 1.0.1-SNAPSHOT ............. SKIPPED
[INFO] Rhyme - AEM Integration 1.0.0-SNAPSHOT ............. SKIPPED
[INFO] Rhyme - AEM Example Complete Package 1.0.0-SNAPSHOT  SKIPPED
[INFO] Rhyme - AEM Example Config Definition 1.0.0-SNAPSHOT SKIPPED
[INFO] Rhyme - AEM Example 1.0.0-SNAPSHOT ................. SKIPPED
[INFO] Rhyme - AWS Movie Search Example 1-SNAPSHOT ........ SKIPPED
[INFO] Rhyme - OSGi/JAX-RS Integration 1.1.1-SNAPSHOT ..... SKIPPED
[INFO] Rhyme - OSGI/JAX-RS Example Service 1.0.0-SNAPSHOT . SKIPPED
[INFO] Rhyme - OSGI/JAX-RS Integration Test Launchpad 1-SNAPSHOT SKIPPED
[INFO] Rhyme - Spring Boot Hello World Example 1-SNAPSHOT . SKIPPED
[INFO] Rhyme - Spring Integration 1.0.1-SNAPSHOT .......... SKIPPED
[INFO] Rhyme - Spring Boot Hypermedia Example 1-SNAPSHOT .. SKIPPED
[INFO] Rhyme - Code Coverage 1-SNAPSHOT ................... SKIPPED
[INFO] Rhyme 1 ............................................ SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  33.677 s
[INFO] Finished at: 2023-07-25T15:28:29+02:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal on project io.wcm.caravan.rhyme.examples.aem-hal-browser.core: Could not resolve dependencies for project io.wcm.caravan:io.wcm.caravan.rhyme.examples.aem-hal-browser.core:jar:1.0.0-SNAPSHOT: Could not find artifact .io.wcm.caravan:io.wcm.caravan.rhyme.aem:jar:1.0.0-SNAPSHOT -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/DependencyResolutionException
[ERROR] 
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <args> -rf :io.wcm.caravan.rhyme.examples.aem-hal-browser.core
```

With the updated modules order in pom.xml the initial build succeeds.