### PR TITLE
Restore old behaviour on "only null parameters" handling

### DIFF
--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/HalApiMethodInvocation.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/HalApiMethodInvocation.java
@@ -22,7 +22,9 @@ package io.wcm.caravan.rhyme.impl.client.proxy;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
+import java.util.Arrays;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -46,6 +48,7 @@ class HalApiMethodInvocation {
   private final HalApiTypeSupport typeSupport;
 
   private final Map<String, Object> templateVariables;
+  private final boolean calledWithOnlyNullParameters;
 
 
   HalApiMethodInvocation(RequestMetricsCollector metrics, Class interfaze, Method method, Object[] args, HalApiTypeSupport typeSupport) {
@@ -57,6 +60,8 @@ class HalApiMethodInvocation {
       this.typeSupport = typeSupport;
 
       this.templateVariables = TemplateVariableDetection.getVariablesNameValueMap(method, Optional.ofNullable(args));
+
+      this.calledWithOnlyNullParameters = args != null && Arrays.stream(args).allMatch(Objects::isNull);
     }
   }
 
@@ -102,6 +107,11 @@ class HalApiMethodInvocation {
   Class<?> getEmissionType() {
     return emissionType;
   }
+
+  boolean isCalledWithOnlyNullParameters() {
+    return calledWithOnlyNullParameters;
+  }
+
 
   Map<String, Object> getTemplateVariables() {
     return templateVariables;

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/RelatedResourceHandler.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/RelatedResourceHandler.java
@@ -97,6 +97,10 @@ class RelatedResourceHandler implements Function<HalResource, Observable<Object>
     Map<String, Object> variables = invocation.getTemplateVariables();
 
     if (!variables.isEmpty()) {
+      // if null values were specified for all method parameters, we assume that the caller is only interested in the link templates
+      if (invocation.isCalledWithOnlyNullParameters()) {
+        return createProxiesFromLinkTemplates(relatedResourceType, relevantLinks);
+      }
 
       // ignore any resolved links, and only consider link templates that contain all variables specified
       // in the method invocation
@@ -195,4 +199,12 @@ class RelatedResourceHandler implements Function<HalResource, Observable<Object>
     clonedLink.setHref(uri);
     return clonedLink;
   }
+
+  private Observable<Object> createProxiesFromLinkTemplates(Class<?> relatedResourceType, List<Link> links) {
+
+    // do not expand the link templates
+    return Observable.fromIterable(links)
+        .map(link -> proxyFactory.createProxyFromLink(relatedResourceType, link));
+  }
+
 }

--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/client/TemplateVariableTest.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/client/TemplateVariableTest.java
@@ -26,6 +26,7 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 
 import java.lang.reflect.Modifier;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -125,7 +126,7 @@ class TemplateVariableTest {
   @HalApiInterface
   interface ResourceWithComplexLinkTemplate {
 
-    static final String TEMPLATE = "/item/{number}{?optionalFlag}";
+    String TEMPLATE = "/item/{number}{?optionalFlag}";
 
     @Related(ITEM)
     Single<ResourceWithSingleState> getLinked(
@@ -175,6 +176,20 @@ class TemplateVariableTest {
 
     assertThat(link.getHref())
         .isEqualTo(ResourceWithComplexLinkTemplate.TEMPLATE);
+  }
+
+  @HalApiInterface
+  interface ResourceWithOptionalLinkedResource {
+
+    @Related(ITEM)
+    Optional<ResourceWithSingleState> getLinked(@TemplateVariable("number") Integer number);
+  }
+
+  @Test
+  void linked_resource_should_not_be_present_if_there_is_no_link_in_entryPoint() {
+    assertThat(client.createProxy(ResourceWithOptionalLinkedResource.class)
+        .getLinked(null))
+        .isNotPresent();
   }
 
   @Test


### PR DESCRIPTION
This fixes a regression in a dependent project.

Unfortunately I'm currently not able to isolate the problem in an unit test. I suppose TemplateVariableTest#link_template_should_be_preserved_if_all_parameters_are_null should prevent this issue, but this test wasn't failing.
The main difference in the project we're using caravan rhyme is the test setup is using "real mocked http" via wiremock and doesn't use the MockClientTestSupport.