### PR TITLE
Execute deployment with Java 17 to enable build and deploy of the spring related projects

### DIFF
--- a/.github/workflows/maven-deploy.yml
+++ b/.github/workflows/maven-deploy.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
           cache: maven
 
       - name: Build, verify, deploy, generate site


### PR DESCRIPTION
I hope you agree to execute the deployment process with a JDK 17 to enable build and deploy of the Spring related projects after the Spring Boot 3 upgrade in #47 

I double checked locally that this will still produce Java 11 compatible class files in the other projects (e.g. core):
```
caravan-rhyme$ javap -v integration/spring/target/classes/io/wcm/caravan/rhyme/spring/api/SpringRhyme.class  | grep major
  major version: 61
caravan-rhyme$ javap -v core/target/classes/io/wcm/caravan/rhyme/api/Rhyme.class | grep major
  major version: 55
```