### PR TITLE
Provide the ability to customize the WebClient instance used in the HalResourceLoader

### DIFF
--- a/integration/spring/src/main/java/io/wcm/caravan/rhyme/spring/api/HttpClientCustomizer.java
+++ b/integration/spring/src/main/java/io/wcm/caravan/rhyme/spring/api/HttpClientCustomizer.java
@@ -1,0 +1,17 @@
+package io.wcm.caravan.rhyme.spring.api;
+
+import reactor.netty.http.client.HttpClient;
+
+/**
+ * Callback interface that can be used to customize a {@link reactor.netty.http.client.HttpClient}. E.g., to add a proxy configuration.
+ */
+@FunctionalInterface
+public interface HttpClientCustomizer {
+
+  /**
+   * Callback to customize a {@link reactor.netty.http.client.HttpClient} instance.
+   * @param httpClient the client to customize
+   */
+  void customize(HttpClient httpClient);
+
+}

--- a/integration/spring/src/main/java/io/wcm/caravan/rhyme/spring/api/WebClientProvider.java
+++ b/integration/spring/src/main/java/io/wcm/caravan/rhyme/spring/api/WebClientProvider.java
@@ -1,0 +1,18 @@
+package io.wcm.caravan.rhyme.spring.api;
+
+import java.net.URI;
+
+import org.springframework.web.reactive.function.client.WebClient;
+
+/**
+ * Callback interface to provide an instance of {@link WebClient} for the given uri.
+ */
+@FunctionalInterface
+public interface WebClientProvider {
+
+  /**
+   * Returns an instance of {@link WebClient} for the given uri.
+   */
+  WebClient webClientForUri(URI uri);
+
+}

--- a/integration/spring/src/main/java/io/wcm/caravan/rhyme/spring/impl/SpringRhymeAutoConfiguration.java
+++ b/integration/spring/src/main/java/io/wcm/caravan/rhyme/spring/impl/SpringRhymeAutoConfiguration.java
@@ -19,15 +19,23 @@
  */
 package io.wcm.caravan.rhyme.spring.impl;
 
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import io.wcm.caravan.rhyme.api.client.HalResourceLoaderBuilder;
 import io.wcm.caravan.rhyme.api.spi.HalResourceLoader;
+import io.wcm.caravan.rhyme.api.spi.HttpClientSupport;
+import io.wcm.caravan.rhyme.spring.api.HttpClientCustomizer;
 import io.wcm.caravan.rhyme.spring.api.SpringRhyme;
+import io.wcm.caravan.rhyme.spring.api.WebClientProvider;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.resources.ConnectionProvider;
 
 /**
  * Registers all components from the impl package, and provides default implementations for spring beans required by
@@ -46,25 +54,64 @@ class SpringRhymeAutoConfiguration {
    */
   @Bean
   @ConditionalOnMissingBean
-  HalResourceLoader halResourceLoader() {
+  HalResourceLoader halResourceLoader(HalResourceLoaderBuilder halResourceBuilder) {
 
-    return halResourceBuilder()
+    return halResourceBuilder
         .withMemoryCache()
         .build();
   }
 
   /**
-   * Provides a {@link HalResourceLoaderBuilder} that is already pre-configured to use a {@link WebClientSupport}
+   * Provides a {@link HalResourceLoaderBuilder} that is pre-configured with the given {@link HttpClientSupport}
    * @return a {@link HalResourceLoaderBuilder} that can be further customised before a {@link HalResourceLoader} is
-   *         built
+   *     built
    */
   @Bean
   @ConditionalOnMissingBean
-  HalResourceLoaderBuilder halResourceBuilder() {
-
-    WebClientSupport client = new WebClientSupport();
-
+  HalResourceLoaderBuilder halResourceBuilder(HttpClientSupport httpClientSupport) {
     return HalResourceLoaderBuilder.create()
-        .withCustomHttpClient(client);
+        .withCustomHttpClient(httpClientSupport);
   }
+
+  /**
+   * Provides a {@link WebClientSupport} instance with the given {@link WebClient}
+   */
+  @Bean
+  @ConditionalOnMissingBean
+  WebClientSupport webClientSupport(WebClientProvider webClientProvider) {
+    return new WebClientSupport(webClientProvider);
+  }
+
+  /**
+   * Simply provides a static instance of {@link WebClient} for all URIs created with the provided {@link WebClient.Builder}.
+   */
+  @Bean
+  @Scope("prototype")
+  @ConditionalOnMissingBean
+  WebClientProvider webClientProvider(WebClient.Builder webClientBuilder) {
+    WebClient webClient = webClientBuilder.build();
+    return uri -> webClient;
+  }
+
+  /**
+   * Provides a default instance for a {@link WebClient.Builder} with a configured {@link ConnectionProvider}.
+   */
+  @Bean
+  @Scope("prototype")
+  @ConditionalOnMissingBean
+  WebClient.Builder defaultRhymeWebClientBuilder(ObjectProvider<HttpClientCustomizer> httpClientCustomizerProvider) {
+    ConnectionProvider connectionProvider = ConnectionProvider
+        .builder(SpringRhymeAutoConfiguration.class.getSimpleName())
+        .maxConnections(5000)
+        .build();
+
+    HttpClient httpClient = HttpClient.create(connectionProvider);
+
+    httpClientCustomizerProvider.orderedStream().forEach(customizer -> customizer.customize(httpClient));
+
+    return WebClient.builder()
+        .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(16 * 1024 * 1024))
+        .clientConnector(new ReactorClientHttpConnector(httpClient));
+  }
+
 }

--- a/integration/spring/src/test/java/io/wcm/caravan/rhyme/spring/impl/WebClientSupportTest.java
+++ b/integration/spring/src/test/java/io/wcm/caravan/rhyme/spring/impl/WebClientSupportTest.java
@@ -22,6 +22,7 @@ package io.wcm.caravan.rhyme.spring.impl;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientRequestException;
 
 import io.wcm.caravan.rhyme.api.exceptions.HalApiClientException;
@@ -29,18 +30,19 @@ import io.wcm.caravan.rhyme.api.spi.HalResourceLoader;
 import io.wcm.caravan.rhyme.testing.client.AbstractHalResourceLoaderTest;
 
 /**
- * Runs a set of tests for the {@link WebClientHalResourceLoader} against a Wiremock server
+ * Runs a set of tests for the {@link WebClientSupport} based HalResourceLoader against a Wiremock server
  */
 class WebClientSupportTest extends AbstractHalResourceLoaderTest {
 
   @Override
   protected HalResourceLoader createLoaderUnderTest() {
 
-    return HalResourceLoader.create(new WebClientSupport());
+    WebClient webClient = WebClient.create();
+    return HalResourceLoader.create(new WebClientSupport(uri -> webClient));
   }
 
   // after upgrading to Spring Boot 2.5.8, WebClient is handling a few edge cases differently,
-  // so for now we are overriding the text with updated expectations
+  // so for now we are overriding the test with updated expectations
 
   @Override
   @Test


### PR DESCRIPTION
Let the user of this library provide its own WebClient in the Spring context if desired and don't recreate the WebClient on each request