### PR TITLE
osgi-jaxrs-example-launchpad: Re-enable "keep-running" profile

### DIFF
--- a/examples/osgi-jaxrs-example-launchpad/pom.xml
+++ b/examples/osgi-jaxrs-example-launchpad/pom.xml
@@ -231,15 +231,6 @@
             </launch>
           </launches>
         </configuration>
-        <executions>
-          <execution>
-            <id>launcher-start</id>
-            <goals>
-              <goal>start</goal>
-              <goal>stop</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
 
       <plugin>
@@ -297,4 +288,57 @@
     </plugins>
   </build>
   
+  <profiles>
+
+    <!-- Default profile: Stop feature launcher after running ITs -->
+    <profile>
+      <id>start-stop</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>feature-launcher-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>launcher-start</id>
+                <goals>
+                  <goal>start</goal>
+                  <goal>stop</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <!-- Run feature launcher on port 8080 and keep it running after ITs (you have to stop it manually) -->
+    <profile>
+      <id>keep-running</id>
+      <properties>
+        <http.port>8080</http.port>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>feature-launcher-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>launcher-start</id>
+                <goals>
+                  <goal>start</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+  </profiles>
+
 </project>

--- a/examples/osgi-jaxrs-example-launchpad/pom.xml
+++ b/examples/osgi-jaxrs-example-launchpad/pom.xml
@@ -201,7 +201,7 @@
       <plugin>
         <groupId>org.apache.sling</groupId>
         <artifactId>feature-launcher-maven-plugin</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1-SNAPSHOT</version>
         <configuration>
           <launches>
             <launch>
@@ -326,6 +326,9 @@
           <plugin>
             <groupId>org.apache.sling</groupId>
             <artifactId>feature-launcher-maven-plugin</artifactId>
+            <configuration>
+              <trackProcess>false</trackProcess>
+            </configuration>
             <executions>
               <execution>
                 <id>launcher-start</id>


### PR DESCRIPTION
this workaround is basically doing the job to skip the stop goal and set to a fixed port when activating the "keep-running" profile.

but it has a problem: the featurelauncher maven plugin has a special logic to check if the process is still running when maven ends, and then forcibly stopping the instance. because of a bug, that's not working on windows, but on linux it should really kill the process.

so, to have a real solution the featurelauncher maven plugin needs to be extended in a way, that it can be configured to keep the instance running.