### PR TITLE
Fix Java 21 empty collection URI template bug and bump core to 1.2.1-SNAPSHOT

### DIFF
--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/RelatedResourceHandler.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/RelatedResourceHandler.java
@@ -208,10 +208,7 @@ class RelatedResourceHandler implements Function<HalResource, Observable<Object>
     if (value instanceof Iterable) {
       return !((Iterable<?>)value).iterator().hasNext();
     }
-    if (value.getClass().isArray()) {
-      return java.lang.reflect.Array.getLength(value) == 0;
-    }
-    return false;
+    return value.getClass().isArray() && java.lang.reflect.Array.getLength(value) == 0;
   }
 
   private Observable<Object> createProxiesFromLinkTemplates(Class<?> relatedResourceType, List<Link> links) {

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/RelatedResourceHandler.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/RelatedResourceHandler.java
@@ -189,8 +189,12 @@ class RelatedResourceHandler implements Function<HalResource, Observable<Object>
 
   private static Link expandLinkTemplates(Link link, Map<String, Object> parameters) {
 
+    // Workaround for a Java 21 issue: the UriTemplate class can no longer expand
+    // a query parameter template with an empty list/array value.
+    // Skip empty iterables in addition to null values.
     Map<String, Object> parametersWithNonNullValues = parameters.entrySet().stream()
         .filter(entry -> entry.getValue() != null)
+        .filter(entry -> !isEmptyIterable(entry.getValue()))
         .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
 
     String uri = UriTemplate.expandPartial(link.getHref(), parametersWithNonNullValues);
@@ -198,6 +202,10 @@ class RelatedResourceHandler implements Function<HalResource, Observable<Object>
     Link clonedLink = new Link(link.getModel().deepCopy());
     clonedLink.setHref(uri);
     return clonedLink;
+  }
+
+  private static boolean isEmptyIterable(Object value) {
+    return value instanceof Iterable && !((Iterable<?>)value).iterator().hasNext();
   }
 
   private Observable<Object> createProxiesFromLinkTemplates(Class<?> relatedResourceType, List<Link> links) {

--- a/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/RelatedResourceHandler.java
+++ b/core/src/main/java/io/wcm/caravan/rhyme/impl/client/proxy/RelatedResourceHandler.java
@@ -194,7 +194,7 @@ class RelatedResourceHandler implements Function<HalResource, Observable<Object>
     // Skip empty iterables in addition to null values.
     Map<String, Object> parametersWithNonNullValues = parameters.entrySet().stream()
         .filter(entry -> entry.getValue() != null)
-        .filter(entry -> !isEmptyIterable(entry.getValue()))
+        .filter(entry -> !isEmptyCollection(entry.getValue()))
         .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
 
     String uri = UriTemplate.expandPartial(link.getHref(), parametersWithNonNullValues);
@@ -204,8 +204,14 @@ class RelatedResourceHandler implements Function<HalResource, Observable<Object>
     return clonedLink;
   }
 
-  private static boolean isEmptyIterable(Object value) {
-    return value instanceof Iterable && !((Iterable<?>)value).iterator().hasNext();
+  private static boolean isEmptyCollection(Object value) {
+    if (value instanceof Iterable) {
+      return !((Iterable<?>)value).iterator().hasNext();
+    }
+    if (value.getClass().isArray()) {
+      return java.lang.reflect.Array.getLength(value) == 0;
+    }
+    return false;
   }
 
   private Observable<Object> createProxiesFromLinkTemplates(Class<?> relatedResourceType, List<Link> links) {

--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/client/TemplateVariableTest.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/client/TemplateVariableTest.java
@@ -456,6 +456,32 @@ class TemplateVariableTest {
     assertThat(link.getHref()).doesNotContain("ids=");
   }
 
+  @Test
+  void array_template_variable_with_populated_array_should_expand() {
+
+    entryPoint.addLinks(ITEM, new Link("/items{?ids}"));
+
+    Link link = client.createProxy(ResourceWithArrayTemplateVariable.class)
+        .getLinked(new String[]{ "a", "b" })
+        .map(ResourceWithSingleState::createLink)
+        .blockingGet();
+
+    assertThat(link.getHref()).contains("ids=a,b");
+  }
+
+  @Test
+  void array_template_variable_with_explode_modifier_repeats_parameter_name() {
+
+    entryPoint.addLinks(ITEM, new Link("/items{?ids*}"));
+
+    Link link = client.createProxy(ResourceWithArrayTemplateVariable.class)
+        .getLinked(new String[]{ "a", "b", "c" })
+        .map(ResourceWithSingleState::createLink)
+        .blockingGet();
+
+    assertThat(link.getHref()).isEqualTo("/items?ids=a&ids=b&ids=c");
+  }
+
   @HalApiInterface
   interface ResourceWithListAndScalarTemplateVariables {
 

--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/client/TemplateVariableTest.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/client/TemplateVariableTest.java
@@ -436,6 +436,27 @@ class TemplateVariableTest {
   }
 
   @HalApiInterface
+  interface ResourceWithArrayTemplateVariable {
+
+    @Related(ITEM)
+    Single<ResourceWithSingleState> getLinked(
+        @TemplateVariable("ids") String[] ids);
+  }
+
+  @Test
+  void array_template_variable_with_empty_array_should_not_fail() {
+
+    entryPoint.addLinks(ITEM, new Link("/items{?ids}"));
+
+    Link link = client.createProxy(ResourceWithArrayTemplateVariable.class)
+        .getLinked(new String[0])
+        .map(ResourceWithSingleState::createLink)
+        .blockingGet();
+
+    assertThat(link.getHref()).doesNotContain("ids=");
+  }
+
+  @HalApiInterface
   interface ResourceWithListAndScalarTemplateVariables {
 
     @Related(ITEM)

--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/client/TemplateVariableTest.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/client/TemplateVariableTest.java
@@ -25,6 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
 import java.lang.reflect.Modifier;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -392,6 +393,71 @@ class TemplateVariableTest {
 
     assertThat(ex).isInstanceOf(HalApiDeveloperException.class)
         .hasMessageStartingWith("No matching link template found with relation item");
+  }
+
+  // --- List-typed template variables (Java 21 empty iterable issue) ---
+
+  @HalApiInterface
+  interface ResourceWithListTemplateVariable {
+
+    @Related(ITEM)
+    Single<ResourceWithSingleState> getLinked(
+        @TemplateVariable("ids") List<String> ids);
+  }
+
+  @Test
+  void list_template_variable_with_populated_list_should_expand() {
+
+    entryPoint.addLinks(ITEM, new Link("/items{?ids}"));
+
+    mockHalResponseWithNumber("/items?ids=1,2,3", 42);
+
+    TestResourceState state = client.createProxy(ResourceWithListTemplateVariable.class)
+        .getLinked(List.of("1", "2", "3"))
+        .flatMap(ResourceWithSingleState::getProperties)
+        .blockingGet();
+
+    assertThat(state.number).isEqualTo(42);
+  }
+
+  @Test
+  void list_template_variable_with_empty_list_should_not_fail() {
+
+    entryPoint.addLinks(ITEM, new Link("/items{?ids}"));
+
+    mockHalResponseWithNumber("/items", 0);
+
+    Link link = client.createProxy(ResourceWithListTemplateVariable.class)
+        .getLinked(Collections.emptyList())
+        .map(ResourceWithSingleState::createLink)
+        .blockingGet();
+
+    assertThat(link.getHref()).doesNotContain("ids=");
+  }
+
+  @HalApiInterface
+  interface ResourceWithListAndScalarTemplateVariables {
+
+    @Related(ITEM)
+    Single<ResourceWithSingleState> getLinked(
+        @TemplateVariable("ids") List<String> ids,
+        @TemplateVariable("filter") String filter);
+  }
+
+  @Test
+  void empty_list_template_variable_with_scalar_should_not_fail() {
+
+    entryPoint.addLinks(ITEM, new Link("/items{?ids,filter}"));
+
+    mockHalResponseWithNumber("/items?filter=active", 7);
+
+    Link link = client.createProxy(ResourceWithListAndScalarTemplateVariables.class)
+        .getLinked(Collections.emptyList(), "active")
+        .map(ResourceWithSingleState::createLink)
+        .blockingGet();
+
+    assertThat(link.getHref()).contains("filter=active");
+    assertThat(link.getHref()).doesNotContain("ids=");
   }
 
   @HalApiInterface

--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/client/TemplateVariableTest.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/client/TemplateVariableTest.java
@@ -313,6 +313,88 @@ class TemplateVariableTest {
 
 
   @HalApiInterface
+  interface ResourceWithTwoQueryTemplateVariables {
+
+    @Related(ITEM)
+    Single<ResourceWithSingleState> getLinked(
+        @TemplateVariable("a") String a,
+        @TemplateVariable("b") String b);
+  }
+
+  @Test
+  void template_with_query_expansion_should_match_variables() {
+
+    entryPoint.addLinks(ITEM, new Link("/items{?a,b}"));
+
+    mockHalResponseWithNumber("/items?a=1&b=2", 12);
+
+    TestResourceState state = client.createProxy(ResourceWithTwoQueryTemplateVariables.class)
+        .getLinked("1", "2")
+        .flatMap(ResourceWithSingleState::getProperties)
+        .blockingGet();
+
+    assertThat(state.number).isEqualTo(12);
+  }
+
+  @HalApiInterface
+  interface ResourceWithThreeQueryTemplateVariables {
+
+    @Related(ITEM)
+    Single<ResourceWithSingleState> getLinked(
+        @TemplateVariable("a") String a,
+        @TemplateVariable("b") String b,
+        @TemplateVariable("c") String c);
+  }
+
+  @Test
+  void template_with_multiple_query_variables_should_expand_first_and_preserve_rest() {
+
+    entryPoint.addLinks(ITEM, new Link("/items{?a,b,c}"));
+
+    Link link = client.createProxy(ResourceWithThreeQueryTemplateVariables.class)
+        .getLinked("1", null, null)
+        .map(ResourceWithSingleState::createLink)
+        .blockingGet();
+
+    assertThat(link.getHref())
+        .isEqualTo("/items?a=1{&b,c}");
+  }
+
+  @Test
+  void link_template_with_special_characters_should_be_url_encoded() {
+
+    entryPoint.addLinks(ITEM, new Link("/items{?a,b}"));
+
+    // the partial expansion will encode the space character and the resource loader
+    // will be called with the encoded URL
+    mockHalResponseWithNumber("/items?a=hello%20world", 99);
+
+    Link link = client.createProxy(ResourceWithTwoQueryTemplateVariables.class)
+        .getLinked("hello world", null)
+        .map(ResourceWithSingleState::createLink)
+        .blockingGet();
+
+    assertThat(link.getHref())
+        .startsWith("/items?a=hello")
+        .doesNotContain("{?")
+        .contains("{&b}");
+  }
+
+  @Test
+  void link_template_should_not_match_when_extra_non_null_variable_provided() {
+
+    entryPoint.addLinks(ITEM, new Link("/items{?a}"));
+
+    Throwable ex = catchThrowable(() -> client.createProxy(ResourceWithTwoQueryTemplateVariables.class)
+        .getLinked("1", "2")
+        .flatMap(ResourceWithSingleState::getProperties)
+        .blockingGet());
+
+    assertThat(ex).isInstanceOf(HalApiDeveloperException.class)
+        .hasMessageStartingWith("No matching link template found with relation item");
+  }
+
+  @HalApiInterface
   public interface ResourceWithMissingAnnotations {
 
     @Related(ITEM)

--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/client/TemplatedResourceLoadingTest.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/client/TemplatedResourceLoadingTest.java
@@ -19,7 +19,6 @@
  */
 package io.wcm.caravan.rhyme.impl.client;
 
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 
 import org.junit.jupiter.api.Test;

--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/client/TemplatedResourceLoadingTest.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/client/TemplatedResourceLoadingTest.java
@@ -1,0 +1,95 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2021 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.caravan.rhyme.impl.client;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.Test;
+
+import io.reactivex.rxjava3.core.Single;
+import io.wcm.caravan.rhyme.api.annotations.HalApiInterface;
+import io.wcm.caravan.rhyme.api.annotations.ResourceState;
+import io.wcm.caravan.rhyme.api.client.HalApiClient;
+import io.wcm.caravan.rhyme.api.client.HalApiClientBuilder;
+import io.wcm.caravan.rhyme.impl.client.ClientTestSupport.MockClientTestSupport;
+import io.wcm.caravan.rhyme.testing.resources.TestResourceState;
+
+/**
+ * Tests that verify the URL template stripping behavior in
+ * {@link io.wcm.caravan.rhyme.impl.client.proxy.HalApiClientProxyFactory#validateUrlAndLoadResourceBody}
+ * when a templated URI is used as the entry point URL.
+ */
+class TemplatedResourceLoadingTest {
+
+  @HalApiInterface
+  interface SimpleResource {
+
+    @ResourceState
+    Single<TestResourceState> getProperties();
+  }
+
+  private final MockClientTestSupport client = ClientTestSupport.withMocking();
+
+  private void loadResourceAndVerifyRequestedUrl(String entryPointUri, String expectedLoadedUrl) {
+
+    client.mockHalResponseWithState(expectedLoadedUrl, new TestResourceState());
+
+    HalApiClient halApiClient = HalApiClientBuilder.create()
+        .withResourceLoader(client.getMockJsonLoader())
+        .build();
+
+    halApiClient.getRemoteResource(entryPointUri, SimpleResource.class)
+        .getProperties()
+        .blockingGet();
+
+    verify(client.getMockJsonLoader()).getHalResource(expectedLoadedUrl);
+  }
+
+  @Test
+  void should_load_non_templated_url_without_modification() {
+
+    loadResourceAndVerifyRequestedUrl("/items", "/items");
+  }
+
+  @Test
+  void should_strip_query_template_when_loading_resource() {
+
+    loadResourceAndVerifyRequestedUrl("/items{?page}", "/items");
+  }
+
+  @Test
+  void should_strip_path_template_when_loading_resource() {
+
+    loadResourceAndVerifyRequestedUrl("/items/{id}", "/items/");
+  }
+
+  @Test
+  void should_strip_mixed_template_expressions() {
+
+    loadResourceAndVerifyRequestedUrl("/items/{id}{?query}", "/items/");
+  }
+
+  @Test
+  void should_strip_plus_template_when_loading_resource() {
+
+    loadResourceAndVerifyRequestedUrl("/{+path}.rhyme", "/.rhyme");
+  }
+}

--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/client/UriTemplateEmptyIterableTest.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/client/UriTemplateEmptyIterableTest.java
@@ -149,4 +149,42 @@ class UriTemplateEmptyIterableTest {
       assertThat(ex).isNull();
     }
   }
+
+  @Test
+  void expandPartial_with_empty_array() {
+
+    UriTemplate template = UriTemplate.buildFromTemplate("/test")
+        .query("foo")
+        .build();
+
+    template.set("foo", new String[0]);
+
+    Throwable ex = catchThrowable(template::expandPartial);
+
+    if (IS_JAVA_21_OR_LATER) {
+      assertThat(ex).isInstanceOf(VarExploderException.class);
+    }
+    else {
+      assertThat(ex).isNull();
+    }
+  }
+
+  @Test
+  void expand_with_empty_array() {
+
+    UriTemplate template = UriTemplate.buildFromTemplate("/test")
+        .query("foo")
+        .build();
+
+    template.set("foo", new String[0]);
+
+    Throwable ex = catchThrowable(template::expand);
+
+    if (IS_JAVA_21_OR_LATER) {
+      assertThat(ex).isInstanceOf(VarExploderException.class);
+    }
+    else {
+      assertThat(ex).isNull();
+    }
+  }
 }

--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/client/UriTemplateEmptyIterableTest.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/client/UriTemplateEmptyIterableTest.java
@@ -1,0 +1,141 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2021 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.caravan.rhyme.impl.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import java.util.Collections;
+import java.util.regex.PatternSyntaxException;
+
+import org.junit.jupiter.api.Test;
+
+import com.damnhandy.uri.template.UriTemplate;
+import com.damnhandy.uri.template.UriTemplateBuilder;
+import com.damnhandy.uri.template.VarExploderException;
+
+/**
+ * Documents two Java 21 issues with handy-uri-templates:
+ *
+ * <h3>Issue 1: Empty iterable expansion</h3>
+ * Expanding a query parameter template with an empty iterable value
+ * throws a {@link VarExploderException} on Java 21.
+ * This affects both explode and non-explode modifiers.
+ *
+ * <h3>Issue 2: Explode modifier in builder</h3>
+ * Calling {@link UriTemplateBuilder#query(String...)} with a name containing
+ * the explode modifier {@code *} (e.g. {@code "foo*"}) throws a
+ * {@link PatternSyntaxException} on Java 21 because the {@code *} character
+ * is invalid in Java regex named capturing groups.
+ *
+ * All modules using {@code UriTemplate.set()} with potentially empty iterables
+ * must guard against this by skipping such variables before expansion.
+ */
+class UriTemplateEmptyIterableTest {
+
+  // --- Issue 1: VarExploderException with empty iterables ---
+
+  @Test
+  void expandPartial_with_empty_list_on_non_explode_template_fails_on_java21() {
+
+    UriTemplate template = UriTemplate.buildFromTemplate("/test")
+        .query("foo")
+        .build();
+
+    template.set("foo", Collections.emptyList());
+
+    Throwable ex = catchThrowable(template::expandPartial);
+
+    assertThat(ex).isInstanceOf(VarExploderException.class);
+  }
+
+  @Test
+  void expand_with_empty_list_on_non_explode_template_fails_on_java21() {
+
+    UriTemplate template = UriTemplate.buildFromTemplate("/test")
+        .query("foo")
+        .build();
+
+    template.set("foo", Collections.emptyList());
+
+    Throwable ex = catchThrowable(template::expand);
+
+    assertThat(ex).isInstanceOf(VarExploderException.class);
+  }
+
+  @Test
+  void expandPartial_with_empty_list_and_resolved_string_fails_on_java21() {
+
+    UriTemplate template = UriTemplate.buildFromTemplate("/test")
+        .query("foo", "bar")
+        .build();
+
+    template.set("foo", Collections.emptyList());
+    template.set("bar", "value");
+
+    Throwable ex = catchThrowable(template::expandPartial);
+
+    assertThat(ex).isInstanceOf(VarExploderException.class);
+  }
+
+  @Test
+  void expandPartial_with_empty_list_via_fromTemplate_non_explode_fails_on_java21() {
+
+    UriTemplate template = UriTemplate.fromTemplate("/test{?foo}");
+    template.set("foo", Collections.emptyList());
+
+    Throwable ex = catchThrowable(template::expandPartial);
+
+    assertThat(ex).isInstanceOf(VarExploderException.class);
+  }
+
+  @Test
+  void expandPartial_with_empty_list_via_fromTemplate_explode_fails_on_java21() {
+
+    UriTemplate template = UriTemplate.fromTemplate("/test{?foo*}");
+    template.set("foo", Collections.emptyList());
+
+    Throwable ex = catchThrowable(template::expandPartial);
+
+    assertThat(ex).isInstanceOf(VarExploderException.class);
+  }
+
+  // --- Issue 2: PatternSyntaxException with explode modifier in builder ---
+
+  @Test
+  void builder_query_with_explode_modifier_fails_on_java21() {
+
+    Throwable ex = catchThrowable(() -> UriTemplate.buildFromTemplate("/test")
+        .query("foo*")
+        .build());
+
+    assertThat(ex).isInstanceOf(PatternSyntaxException.class);
+  }
+
+  @Test
+  void builder_query_with_explode_modifier_mixed_fails_on_java21() {
+
+    Throwable ex = catchThrowable(() -> UriTemplate.buildFromTemplate("/test")
+        .query("foo*", "bar")
+        .build());
+
+    assertThat(ex).isInstanceOf(PatternSyntaxException.class);
+  }
+}

--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/client/UriTemplateEmptyIterableTest.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/client/UriTemplateEmptyIterableTest.java
@@ -23,51 +23,46 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
 import java.util.Collections;
-import java.util.regex.PatternSyntaxException;
 
 import org.junit.jupiter.api.Test;
 
 import com.damnhandy.uri.template.UriTemplate;
-import com.damnhandy.uri.template.UriTemplateBuilder;
-import com.damnhandy.uri.template.VarExploderException;
 
 /**
- * Documents two Java 21 issues with handy-uri-templates:
+ * Tests that verify the expected behavior when expanding URI templates with empty
+ * iterable values. On Java 21, the handy-uri-templates library throws a
+ * {@code VarExploderException} for these cases, while on earlier JDK versions
+ * the expansion succeeds.
  *
- * <h3>Issue 1: Empty iterable expansion</h3>
- * Expanding a query parameter template with an empty iterable value
- * throws a {@link VarExploderException} on Java 21.
- * This affects both explode and non-explode modifiers.
- *
- * <h3>Issue 2: Explode modifier in builder</h3>
- * Calling {@link UriTemplateBuilder#query(String...)} with a name containing
- * the explode modifier {@code *} (e.g. {@code "foo*"}) throws a
- * {@link PatternSyntaxException} on Java 21 because the {@code *} character
- * is invalid in Java regex named capturing groups.
- *
- * All modules using {@code UriTemplate.set()} with potentially empty iterables
- * must guard against this by skipping such variables before expansion.
+ * These tests verify that the expansion either produces the correct result
+ * or fails — establishing the behavioral contract that any workaround or
+ * replacement library must satisfy.
  */
 class UriTemplateEmptyIterableTest {
 
-  // --- Issue 1: VarExploderException with empty iterables ---
-
-  @Test
-  void expandPartial_with_empty_list_on_non_explode_template_fails_on_java21() {
-
-    UriTemplate template = UriTemplate.buildFromTemplate("/test")
-        .query("foo")
-        .build();
-
-    template.set("foo", Collections.emptyList());
-
+  /**
+   * Attempts to expand a UriTemplate with the given empty-list variable set.
+   * Returns the expanded result, or null if the library throws an exception
+   * (as it does on Java 21).
+   */
+  private static String expandPartialOrNull(UriTemplate template) {
     Throwable ex = catchThrowable(template::expandPartial);
+    if (ex != null) {
+      return null;
+    }
+    return template.expandPartial();
+  }
 
-    assertThat(ex).isInstanceOf(VarExploderException.class);
+  private static String expandOrNull(UriTemplate template) {
+    Throwable ex = catchThrowable(template::expand);
+    if (ex != null) {
+      return null;
+    }
+    return template.expand();
   }
 
   @Test
-  void expand_with_empty_list_on_non_explode_template_fails_on_java21() {
+  void expandPartial_with_empty_list_should_produce_url_without_query_or_fail() {
 
     UriTemplate template = UriTemplate.buildFromTemplate("/test")
         .query("foo")
@@ -75,13 +70,31 @@ class UriTemplateEmptyIterableTest {
 
     template.set("foo", Collections.emptyList());
 
-    Throwable ex = catchThrowable(template::expand);
+    String result = expandPartialOrNull(template);
 
-    assertThat(ex).isInstanceOf(VarExploderException.class);
+    if (result != null) {
+      assertThat(result).isEqualTo("/test");
+    }
   }
 
   @Test
-  void expandPartial_with_empty_list_and_resolved_string_fails_on_java21() {
+  void expand_with_empty_list_should_produce_url_without_query_or_fail() {
+
+    UriTemplate template = UriTemplate.buildFromTemplate("/test")
+        .query("foo")
+        .build();
+
+    template.set("foo", Collections.emptyList());
+
+    String result = expandOrNull(template);
+
+    if (result != null) {
+      assertThat(result).isEqualTo("/test");
+    }
+  }
+
+  @Test
+  void expandPartial_with_empty_list_and_resolved_string_should_keep_string_or_fail() {
 
     UriTemplate template = UriTemplate.buildFromTemplate("/test")
         .query("foo", "bar")
@@ -90,52 +103,49 @@ class UriTemplateEmptyIterableTest {
     template.set("foo", Collections.emptyList());
     template.set("bar", "value");
 
-    Throwable ex = catchThrowable(template::expandPartial);
+    String result = expandPartialOrNull(template);
 
-    assertThat(ex).isInstanceOf(VarExploderException.class);
+    if (result != null) {
+      assertThat(result).contains("bar=value");
+      assertThat(result).doesNotContain("foo=");
+    }
   }
 
   @Test
-  void expandPartial_with_empty_list_via_fromTemplate_non_explode_fails_on_java21() {
+  void expandPartial_via_fromTemplate_with_empty_list_should_produce_url_without_query_or_fail() {
 
     UriTemplate template = UriTemplate.fromTemplate("/test{?foo}");
     template.set("foo", Collections.emptyList());
 
-    Throwable ex = catchThrowable(template::expandPartial);
+    String result = expandPartialOrNull(template);
 
-    assertThat(ex).isInstanceOf(VarExploderException.class);
+    if (result != null) {
+      assertThat(result).isEqualTo("/test");
+    }
   }
 
   @Test
-  void expandPartial_with_empty_list_via_fromTemplate_explode_fails_on_java21() {
+  void expandPartial_via_fromTemplate_explode_with_empty_list_should_produce_url_without_query_or_fail() {
 
     UriTemplate template = UriTemplate.fromTemplate("/test{?foo*}");
     template.set("foo", Collections.emptyList());
 
-    Throwable ex = catchThrowable(template::expandPartial);
+    String result = expandPartialOrNull(template);
 
-    assertThat(ex).isInstanceOf(VarExploderException.class);
-  }
-
-  // --- Issue 2: PatternSyntaxException with explode modifier in builder ---
-
-  @Test
-  void builder_query_with_explode_modifier_fails_on_java21() {
-
-    Throwable ex = catchThrowable(() -> UriTemplate.buildFromTemplate("/test")
-        .query("foo*")
-        .build());
-
-    assertThat(ex).isInstanceOf(PatternSyntaxException.class);
+    if (result != null) {
+      assertThat(result).isEqualTo("/test");
+    }
   }
 
   @Test
-  void builder_query_with_explode_modifier_mixed_fails_on_java21() {
+  void static_expandPartial_with_empty_list_should_produce_url_without_query_or_fail() {
 
-    Throwable ex = catchThrowable(() -> UriTemplate.buildFromTemplate("/test")
-        .query("foo*", "bar")
-        .build());
+    Throwable ex = catchThrowable(
+        () -> UriTemplate.expandPartial("/test{?foo}", Collections.singletonMap("foo", Collections.emptyList())));
 
-    assertThat(ex).isInstanceOf(PatternSyntaxException.class);
+    if (ex == null) {
+      String result = UriTemplate.expandPartial("/test{?foo}", Collections.singletonMap("foo", Collections.emptyList()));
+      assertThat(result).isEqualTo("/test");
+    }
   }
 }

--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/client/UriTemplateEmptyIterableTest.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/client/UriTemplateEmptyIterableTest.java
@@ -187,4 +187,5 @@ class UriTemplateEmptyIterableTest {
       assertThat(ex).isNull();
     }
   }
+
 }

--- a/core/src/test/java/io/wcm/caravan/rhyme/impl/client/UriTemplateEmptyIterableTest.java
+++ b/core/src/test/java/io/wcm/caravan/rhyme/impl/client/UriTemplateEmptyIterableTest.java
@@ -27,74 +27,65 @@ import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
 import com.damnhandy.uri.template.UriTemplate;
+import com.damnhandy.uri.template.VarExploderException;
 
 /**
  * Tests that verify the expected behavior when expanding URI templates with empty
- * iterable values. On Java 21, the handy-uri-templates library throws a
- * {@code VarExploderException} for these cases, while on earlier JDK versions
- * the expansion succeeds.
+ * iterable values. On Java 21+, the handy-uri-templates library throws a
+ * {@link VarExploderException} for these cases, while on earlier JDK versions
+ * the expansion succeeds and produces the correct result.
  *
- * These tests verify that the expansion either produces the correct result
- * or fails — establishing the behavioral contract that any workaround or
- * replacement library must satisfy.
+ * Each test verifies both sides of this contract:
+ * <ul>
+ *   <li>On Java &lt; 21: expansion succeeds and produces the expected URL</li>
+ *   <li>On Java &ge; 21: expansion fails with {@link VarExploderException}</li>
+ * </ul>
  */
 class UriTemplateEmptyIterableTest {
 
-  /**
-   * Attempts to expand a UriTemplate with the given empty-list variable set.
-   * Returns the expanded result, or null if the library throws an exception
-   * (as it does on Java 21).
-   */
-  private static String expandPartialOrNull(UriTemplate template) {
+  private static final int JAVA_VERSION = Runtime.version().feature();
+  private static final boolean IS_JAVA_21_OR_LATER = JAVA_VERSION >= 21;
+
+  @Test
+  void expandPartial_with_empty_list_on_non_explode_template() {
+
+    UriTemplate template = UriTemplate.buildFromTemplate("/test")
+        .query("foo")
+        .build();
+
+    template.set("foo", Collections.emptyList());
+
     Throwable ex = catchThrowable(template::expandPartial);
-    if (ex != null) {
-      return null;
+
+    if (IS_JAVA_21_OR_LATER) {
+      assertThat(ex).isInstanceOf(VarExploderException.class);
     }
-    return template.expandPartial();
+    else {
+      assertThat(ex).isNull();
+    }
   }
 
-  private static String expandOrNull(UriTemplate template) {
+  @Test
+  void expand_with_empty_list_on_non_explode_template() {
+
+    UriTemplate template = UriTemplate.buildFromTemplate("/test")
+        .query("foo")
+        .build();
+
+    template.set("foo", Collections.emptyList());
+
     Throwable ex = catchThrowable(template::expand);
-    if (ex != null) {
-      return null;
+
+    if (IS_JAVA_21_OR_LATER) {
+      assertThat(ex).isInstanceOf(VarExploderException.class);
     }
-    return template.expand();
-  }
-
-  @Test
-  void expandPartial_with_empty_list_should_produce_url_without_query_or_fail() {
-
-    UriTemplate template = UriTemplate.buildFromTemplate("/test")
-        .query("foo")
-        .build();
-
-    template.set("foo", Collections.emptyList());
-
-    String result = expandPartialOrNull(template);
-
-    if (result != null) {
-      assertThat(result).isEqualTo("/test");
+    else {
+      assertThat(ex).isNull();
     }
   }
 
   @Test
-  void expand_with_empty_list_should_produce_url_without_query_or_fail() {
-
-    UriTemplate template = UriTemplate.buildFromTemplate("/test")
-        .query("foo")
-        .build();
-
-    template.set("foo", Collections.emptyList());
-
-    String result = expandOrNull(template);
-
-    if (result != null) {
-      assertThat(result).isEqualTo("/test");
-    }
-  }
-
-  @Test
-  void expandPartial_with_empty_list_and_resolved_string_should_keep_string_or_fail() {
+  void expandPartial_with_empty_list_and_resolved_string() {
 
     UriTemplate template = UriTemplate.buildFromTemplate("/test")
         .query("foo", "bar")
@@ -103,49 +94,59 @@ class UriTemplateEmptyIterableTest {
     template.set("foo", Collections.emptyList());
     template.set("bar", "value");
 
-    String result = expandPartialOrNull(template);
+    Throwable ex = catchThrowable(template::expandPartial);
 
-    if (result != null) {
-      assertThat(result).contains("bar=value");
-      assertThat(result).doesNotContain("foo=");
+    if (IS_JAVA_21_OR_LATER) {
+      assertThat(ex).isInstanceOf(VarExploderException.class);
+    }
+    else {
+      assertThat(ex).isNull();
     }
   }
 
   @Test
-  void expandPartial_via_fromTemplate_with_empty_list_should_produce_url_without_query_or_fail() {
+  void expandPartial_via_fromTemplate_non_explode_with_empty_list() {
 
     UriTemplate template = UriTemplate.fromTemplate("/test{?foo}");
     template.set("foo", Collections.emptyList());
 
-    String result = expandPartialOrNull(template);
+    Throwable ex = catchThrowable(template::expandPartial);
 
-    if (result != null) {
-      assertThat(result).isEqualTo("/test");
+    if (IS_JAVA_21_OR_LATER) {
+      assertThat(ex).isInstanceOf(VarExploderException.class);
+    }
+    else {
+      assertThat(ex).isNull();
     }
   }
 
   @Test
-  void expandPartial_via_fromTemplate_explode_with_empty_list_should_produce_url_without_query_or_fail() {
+  void expandPartial_via_fromTemplate_explode_with_empty_list() {
 
     UriTemplate template = UriTemplate.fromTemplate("/test{?foo*}");
     template.set("foo", Collections.emptyList());
 
-    String result = expandPartialOrNull(template);
+    Throwable ex = catchThrowable(template::expandPartial);
 
-    if (result != null) {
-      assertThat(result).isEqualTo("/test");
+    if (IS_JAVA_21_OR_LATER) {
+      assertThat(ex).isInstanceOf(VarExploderException.class);
+    }
+    else {
+      assertThat(ex).isNull();
     }
   }
 
   @Test
-  void static_expandPartial_with_empty_list_should_produce_url_without_query_or_fail() {
+  void static_expandPartial_with_empty_list() {
 
     Throwable ex = catchThrowable(
         () -> UriTemplate.expandPartial("/test{?foo}", Collections.singletonMap("foo", Collections.emptyList())));
 
-    if (ex == null) {
-      String result = UriTemplate.expandPartial("/test{?foo}", Collections.singletonMap("foo", Collections.emptyList()));
-      assertThat(result).isEqualTo("/test");
+    if (IS_JAVA_21_OR_LATER) {
+      assertThat(ex).isInstanceOf(VarExploderException.class);
+    }
+    else {
+      assertThat(ex).isNull();
     }
   }
 }

--- a/examples/aws-movie-search/pom.xml
+++ b/examples/aws-movie-search/pom.xml
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>io.wcm.caravan</groupId>
       <artifactId>io.wcm.caravan.rhyme.core</artifactId>
-      <version>1.2.0</version>
+      <version>1.2.1-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
 

--- a/examples/aws-movie-search/src/main/java/io/wcm/caravan/rhyme/awslambda/impl/LambdaLinkBuilderImpl.java
+++ b/examples/aws-movie-search/src/main/java/io/wcm/caravan/rhyme/awslambda/impl/LambdaLinkBuilderImpl.java
@@ -52,7 +52,7 @@ class LambdaLinkBuilderImpl implements LambdaLinkBuilder {
 
     for (String name : variableNames) {
       Object value = nonNullVariableValues.get(name);
-      if (value instanceof Iterable && !((Iterable<?>)value).iterator().hasNext()) {
+      if (isEmptyCollection(value)) {
         effectiveValues.remove(name);
         continue;
       }
@@ -72,5 +72,15 @@ class LambdaLinkBuilderImpl implements LambdaLinkBuilder {
         .expandPartial();
 
     return new Link(expandedTemplate);
+  }
+
+  private static boolean isEmptyCollection(Object value) {
+    if (value instanceof Iterable) {
+      return !((Iterable<?>)value).iterator().hasNext();
+    }
+    if (value != null && value.getClass().isArray()) {
+      return java.lang.reflect.Array.getLength(value) == 0;
+    }
+    return false;
   }
 }

--- a/examples/aws-movie-search/src/main/java/io/wcm/caravan/rhyme/awslambda/impl/LambdaLinkBuilderImpl.java
+++ b/examples/aws-movie-search/src/main/java/io/wcm/caravan/rhyme/awslambda/impl/LambdaLinkBuilderImpl.java
@@ -44,12 +44,31 @@ class LambdaLinkBuilderImpl implements LambdaLinkBuilder {
       return new Link(absolutePath);
     }
 
+    // Workaround for a Java 21 issue: the UriTemplate class can no longer expand
+    // a query parameter template with an empty list/array value.
+    // Skip empty iterables from both the template variables and the value map.
+    List<String> effectiveNames = new ArrayList<>();
+    Map<String, Object> effectiveValues = new LinkedHashMap<>(nonNullVariableValues);
+
+    for (String name : variableNames) {
+      Object value = nonNullVariableValues.get(name);
+      if (value instanceof Iterable && !((Iterable<?>)value).iterator().hasNext()) {
+        effectiveValues.remove(name);
+        continue;
+      }
+      effectiveNames.add(name);
+    }
+
+    if (effectiveNames.isEmpty()) {
+      return new Link(absolutePath);
+    }
+
     UriTemplate template = UriTemplate.buildFromTemplate(absolutePath)
-        .query(variableNames.toArray(new String[0]))
+        .query(effectiveNames.toArray(new String[0]))
         .build();
 
     String expandedTemplate = template
-        .set(nonNullVariableValues)
+        .set(effectiveValues)
         .expandPartial();
 
     return new Link(expandedTemplate);

--- a/examples/aws-movie-search/src/main/java/io/wcm/caravan/rhyme/awslambda/impl/LambdaLinkBuilderImpl.java
+++ b/examples/aws-movie-search/src/main/java/io/wcm/caravan/rhyme/awslambda/impl/LambdaLinkBuilderImpl.java
@@ -75,12 +75,12 @@ class LambdaLinkBuilderImpl implements LambdaLinkBuilder {
   }
 
   private static boolean isEmptyCollection(Object value) {
+    if (value == null) {
+      return false;
+    }
     if (value instanceof Iterable) {
       return !((Iterable<?>)value).iterator().hasNext();
     }
-    if (value != null && value.getClass().isArray()) {
-      return java.lang.reflect.Array.getLength(value) == 0;
-    }
-    return false;
+    return value.getClass().isArray() && java.lang.reflect.Array.getLength(value) == 0;
   }
 }

--- a/examples/aws-movie-search/src/test/java/io/wcm/caravan/rhyme/awslambda/impl/LambdaLinkBuilderImplTest.java
+++ b/examples/aws-movie-search/src/test/java/io/wcm/caravan/rhyme/awslambda/impl/LambdaLinkBuilderImplTest.java
@@ -2,6 +2,8 @@ package io.wcm.caravan.rhyme.awslambda.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Collections;
+
 import org.junit.jupiter.api.Test;
 
 import io.wcm.caravan.hal.resource.Link;
@@ -85,5 +87,40 @@ class LambdaLinkBuilderImplTest {
 
     assertThat(link.getHref())
         .isEqualTo("/items?offset=42");
+  }
+
+  // --- Java 21 empty iterable issue ---
+
+  @Test
+  void should_not_fail_with_empty_list_as_only_variable() {
+
+    Link link = new LambdaLinkBuilderImpl("/items")
+        .addQueryVariable("ids", Collections.emptyList())
+        .build();
+
+    assertThat(link.getHref()).isEqualTo("/items");
+  }
+
+  @Test
+  void should_not_fail_with_empty_list_and_resolved_string_variable() {
+
+    Link link = new LambdaLinkBuilderImpl("/items")
+        .addQueryVariable("ids", Collections.emptyList())
+        .addQueryVariable("filter", "active")
+        .build();
+
+    assertThat(link.getHref()).contains("filter=active");
+    assertThat(link.getHref()).doesNotContain("ids=");
+  }
+
+  @Test
+  void should_not_fail_with_empty_list_and_null_variable() {
+
+    Link link = new LambdaLinkBuilderImpl("/items")
+        .addQueryVariable("ids", Collections.emptyList())
+        .addQueryVariable("page", null)
+        .build();
+
+    assertThat(link.getHref()).doesNotContain("ids=");
   }
 }

--- a/examples/aws-movie-search/src/test/java/io/wcm/caravan/rhyme/awslambda/impl/LambdaLinkBuilderImplTest.java
+++ b/examples/aws-movie-search/src/test/java/io/wcm/caravan/rhyme/awslambda/impl/LambdaLinkBuilderImplTest.java
@@ -123,4 +123,14 @@ class LambdaLinkBuilderImplTest {
 
     assertThat(link.getHref()).doesNotContain("ids=");
   }
+
+  @Test
+  void should_not_fail_with_empty_array_as_only_variable() {
+
+    Link link = new LambdaLinkBuilderImpl("/items")
+        .addQueryVariable("ids", new String[0])
+        .build();
+
+    assertThat(link.getHref()).isEqualTo("/items");
+  }
 }

--- a/examples/aws-movie-search/src/test/java/io/wcm/caravan/rhyme/awslambda/impl/LambdaLinkBuilderImplTest.java
+++ b/examples/aws-movie-search/src/test/java/io/wcm/caravan/rhyme/awslambda/impl/LambdaLinkBuilderImplTest.java
@@ -133,4 +133,16 @@ class LambdaLinkBuilderImplTest {
 
     assertThat(link.getHref()).isEqualTo("/items");
   }
+
+  @Test
+  void should_not_fail_with_empty_array_and_resolved_string_variable() {
+
+    Link link = new LambdaLinkBuilderImpl("/items")
+        .addQueryVariable("ids", new String[0])
+        .addQueryVariable("filter", "active")
+        .build();
+
+    assertThat(link.getHref()).contains("filter=active");
+    assertThat(link.getHref()).doesNotContain("ids=");
+  }
 }

--- a/examples/aws-movie-search/src/test/java/io/wcm/caravan/rhyme/awslambda/impl/LambdaLinkBuilderImplTest.java
+++ b/examples/aws-movie-search/src/test/java/io/wcm/caravan/rhyme/awslambda/impl/LambdaLinkBuilderImplTest.java
@@ -1,0 +1,89 @@
+package io.wcm.caravan.rhyme.awslambda.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import io.wcm.caravan.hal.resource.Link;
+
+class LambdaLinkBuilderImplTest {
+
+  @Test
+  void should_return_plain_link_when_no_variables_are_added() {
+
+    Link link = new LambdaLinkBuilderImpl("/items")
+        .build();
+
+    assertThat(link.getHref())
+        .isEqualTo("/items");
+  }
+
+  @Test
+  void should_return_fully_expanded_link_when_variable_is_non_null() {
+
+    Link link = new LambdaLinkBuilderImpl("/items")
+        .addQueryVariable("page", 1)
+        .build();
+
+    assertThat(link.getHref())
+        .isEqualTo("/items?page=1");
+  }
+
+  @Test
+  void should_return_template_link_when_variable_is_null() {
+
+    Link link = new LambdaLinkBuilderImpl("/items")
+        .addQueryVariable("page", null)
+        .build();
+
+    assertThat(link.getHref())
+        .isEqualTo("/items{?page}");
+  }
+
+  @Test
+  void should_partially_expand_when_some_variables_are_null() {
+
+    Link link = new LambdaLinkBuilderImpl("/items")
+        .addQueryVariable("page", 1)
+        .addQueryVariable("size", null)
+        .build();
+
+    assertThat(link.getHref())
+        .isEqualTo("/items?page=1{&size}");
+  }
+
+  @Test
+  void should_handle_multiple_non_null_variables() {
+
+    Link link = new LambdaLinkBuilderImpl("/items")
+        .addQueryVariable("page", 1)
+        .addQueryVariable("size", 10)
+        .build();
+
+    assertThat(link.getHref())
+        .isEqualTo("/items?page=1&size=10");
+  }
+
+  @Test
+  void should_handle_multiple_null_variables() {
+
+    Link link = new LambdaLinkBuilderImpl("/items")
+        .addQueryVariable("page", null)
+        .addQueryVariable("size", null)
+        .build();
+
+    assertThat(link.getHref())
+        .isEqualTo("/items{?page,size}");
+  }
+
+  @Test
+  void should_handle_integer_variable_values() {
+
+    Link link = new LambdaLinkBuilderImpl("/items")
+        .addQueryVariable("offset", 42)
+        .build();
+
+    assertThat(link.getHref())
+        .isEqualTo("/items?offset=42");
+  }
+}

--- a/examples/aws-movie-search/src/test/java/io/wcm/caravan/rhyme/awslambda/impl/LambdaLinkBuilderImplTest.java
+++ b/examples/aws-movie-search/src/test/java/io/wcm/caravan/rhyme/awslambda/impl/LambdaLinkBuilderImplTest.java
@@ -145,4 +145,14 @@ class LambdaLinkBuilderImplTest {
     assertThat(link.getHref()).contains("filter=active");
     assertThat(link.getHref()).doesNotContain("ids=");
   }
+
+  @Test
+  void should_expand_populated_array_variable() {
+
+    Link link = new LambdaLinkBuilderImpl("/items")
+        .addQueryVariable("ids", new String[]{ "a", "b" })
+        .build();
+
+    assertThat(link.getHref()).contains("ids=a,b");
+  }
 }

--- a/examples/osgi-jaxrs-example-launchpad/pom.xml
+++ b/examples/osgi-jaxrs-example-launchpad/pom.xml
@@ -41,7 +41,7 @@
     <java.version>17</java.version>
     <sling.starter.version>14-SNAPSHOT</sling.starter.version>
     <rhyme.api-interfaces.version>1.1.0</rhyme.api-interfaces.version>
-    <rhyme.core.version>1.2.0</rhyme.core.version>
+    <rhyme.core.version>1.2.1-SNAPSHOT</rhyme.core.version>
     <rhyme.osgi-jaxrs.version>1.1.1-SNAPSHOT</rhyme.osgi-jaxrs.version>
     <rhyme.examples.osgi-jaxrs-example-service.version>1.0.0-SNAPSHOT</rhyme.examples.osgi-jaxrs-example-service.version>
 

--- a/integration/aem/pom.xml
+++ b/integration/aem/pom.xml
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>io.wcm.caravan</groupId>
       <artifactId>io.wcm.caravan.rhyme.core</artifactId>
-      <version>1.2.0</version>
+      <version>1.2.1-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
 

--- a/integration/aem/src/main/java/io/wcm/caravan/rhyme/aem/impl/linkbuilder/SlingLinkBuilderImpl.java
+++ b/integration/aem/src/main/java/io/wcm/caravan/rhyme/aem/impl/linkbuilder/SlingLinkBuilderImpl.java
@@ -92,13 +92,13 @@ public class SlingLinkBuilderImpl implements SlingLinkBuilder {
   }
 
   private static boolean isEmptyCollection(Object value) {
+    if (value == null) {
+      return false;
+    }
     if (value instanceof Iterable) {
       return !((Iterable<?>)value).iterator().hasNext();
     }
-    if (value != null && value.getClass().isArray()) {
-      return java.lang.reflect.Array.getLength(value) == 0;
-    }
-    return false;
+    return value.getClass().isArray() && java.lang.reflect.Array.getLength(value) == 0;
   }
 
   private String getClassSpecificSelector(SlingLinkableResource slingModel) {

--- a/integration/aem/src/main/java/io/wcm/caravan/rhyme/aem/impl/linkbuilder/SlingLinkBuilderImpl.java
+++ b/integration/aem/src/main/java/io/wcm/caravan/rhyme/aem/impl/linkbuilder/SlingLinkBuilderImpl.java
@@ -68,15 +68,31 @@ public class SlingLinkBuilderImpl implements SlingLinkBuilder {
     if (queryParams.isEmpty()) {
       return baseUrl;
     }
-    String[] names = queryParams.keySet().toArray(new String[queryParams.size()]);
+
+    // Workaround for a Java 21 issue: the UriTemplate class can no longer expand
+    // a query parameter template with an empty iterable value.
+    // Skip empty iterables from both the template variable names and the value map.
+    String[] names = queryParams.entrySet().stream()
+        .filter(entry -> !isEmptyIterable(entry.getValue()))
+        .map(Map.Entry::getKey)
+        .toArray(String[]::new);
+
+    if (names.length == 0) {
+      return baseUrl;
+    }
 
     UriTemplate template = UriTemplate.buildFromTemplate(baseUrl).query(names).build();
 
     queryParams.entrySet().stream()
         .filter(entry -> entry.getValue() != null)
+        .filter(entry -> !isEmptyIterable(entry.getValue()))
         .forEach(entry -> template.set(entry.getKey(), entry.getValue()));
 
     return slingModel.getLinkProperties().isTemplated() ? template.expandPartial() : template.expand();
+  }
+
+  private static boolean isEmptyIterable(Object value) {
+    return value instanceof Iterable && !((Iterable<?>)value).iterator().hasNext();
   }
 
   private String getClassSpecificSelector(SlingLinkableResource slingModel) {

--- a/integration/aem/src/main/java/io/wcm/caravan/rhyme/aem/impl/linkbuilder/SlingLinkBuilderImpl.java
+++ b/integration/aem/src/main/java/io/wcm/caravan/rhyme/aem/impl/linkbuilder/SlingLinkBuilderImpl.java
@@ -70,10 +70,10 @@ public class SlingLinkBuilderImpl implements SlingLinkBuilder {
     }
 
     // Workaround for a Java 21 issue: the UriTemplate class can no longer expand
-    // a query parameter template with an empty iterable value.
-    // Skip empty iterables from both the template variable names and the value map.
+    // a query parameter template with an empty list/array value.
+    // Skip empty collections from both the template variable names and the value map.
     String[] names = queryParams.entrySet().stream()
-        .filter(entry -> !isEmptyIterable(entry.getValue()))
+        .filter(entry -> !isEmptyCollection(entry.getValue()))
         .map(Map.Entry::getKey)
         .toArray(String[]::new);
 
@@ -85,14 +85,20 @@ public class SlingLinkBuilderImpl implements SlingLinkBuilder {
 
     queryParams.entrySet().stream()
         .filter(entry -> entry.getValue() != null)
-        .filter(entry -> !isEmptyIterable(entry.getValue()))
+        .filter(entry -> !isEmptyCollection(entry.getValue()))
         .forEach(entry -> template.set(entry.getKey(), entry.getValue()));
 
     return slingModel.getLinkProperties().isTemplated() ? template.expandPartial() : template.expand();
   }
 
-  private static boolean isEmptyIterable(Object value) {
-    return value instanceof Iterable && !((Iterable<?>)value).iterator().hasNext();
+  private static boolean isEmptyCollection(Object value) {
+    if (value instanceof Iterable) {
+      return !((Iterable<?>)value).iterator().hasNext();
+    }
+    if (value != null && value.getClass().isArray()) {
+      return java.lang.reflect.Array.getLength(value) == 0;
+    }
+    return false;
   }
 
   private String getClassSpecificSelector(SlingLinkableResource slingModel) {

--- a/integration/aem/src/test/java/io/wcm/caravan/rhyme/aem/impl/adaptation/TemplateProxyPostAdaptationStageTest.java
+++ b/integration/aem/src/test/java/io/wcm/caravan/rhyme/aem/impl/adaptation/TemplateProxyPostAdaptationStageTest.java
@@ -170,6 +170,46 @@ class TemplateProxyPostAdaptationStageTest {
   }
 
   @Test
+  void withQueryParameterTemplate_appends_single_query_parameter_template() {
+
+    SlingResourceAdapterImpl adapter = createAdapterInstanceForResource("/");
+
+    SlingTestResource resource = adapter.selectResourceAt(null)
+        .adaptTo(SlingTestResource.class)
+        .withQueryParameterTemplate("id")
+        .getInstance();
+
+    assertThat(resource.createLink().getHref()).isEqualTo("{+path}.selectortest.rhyme{?id}");
+  }
+
+  @Test
+  void withQueryParameterTemplate_appends_three_query_parameter_templates() {
+
+    SlingResourceAdapterImpl adapter = createAdapterInstanceForResource("/");
+
+    SlingTestResource resource = adapter.selectResourceAt(null)
+        .adaptTo(SlingTestResource.class)
+        .withQueryParameterTemplate("a", "b", "c")
+        .getInstance();
+
+    assertThat(resource.createLink().getHref()).isEqualTo("{+path}.selectortest.rhyme{?a,b,c}");
+  }
+
+  @Test
+  void selectResourceAt_generates_template_without_query_params_by_default() {
+
+    SlingResourceAdapterImpl adapter = createAdapterInstanceForResource("/");
+
+    SlingTestResource resource = adapter.selectResourceAt(null)
+        .adaptTo(SlingTestResource.class)
+        .getInstance();
+
+    assertThat(resource.createLink().getHref())
+        .doesNotContain("?")
+        .doesNotContain("&");
+  }
+
+  @Test
   void withPartialLinkTemplate_fails_if_null_path_is_given() {
 
     SlingResourceAdapterImpl adapter = createAdapterInstanceForResource("/");

--- a/integration/aem/src/test/java/io/wcm/caravan/rhyme/aem/impl/linkbuilder/SlingLinkBuilderImplTest.java
+++ b/integration/aem/src/test/java/io/wcm/caravan/rhyme/aem/impl/linkbuilder/SlingLinkBuilderImplTest.java
@@ -317,6 +317,9 @@ public class SlingLinkBuilderImplTest {
     @QueryParam
     private String filter;
 
+    @QueryParam
+    private String[] tags;
+
     @Override
     protected String getDefaultLinkTitle() {
       return "resource with list";
@@ -396,6 +399,16 @@ public class SlingLinkBuilderImplTest {
 
     assertThat(link.getHref()).contains("filter=active");
     assertThat(link.getHref()).doesNotContain("ids=");
+  }
+
+  @Test
+  void createLinkToCurrentResource_with_empty_array_param_should_not_fail() {
+
+    Link link = createLinkWithListParams(resource -> {
+      resource.tags = new String[0];
+    });
+
+    assertThat(link.getHref()).isEqualTo("/content.rhyme");
   }
 
 }

--- a/integration/aem/src/test/java/io/wcm/caravan/rhyme/aem/impl/linkbuilder/SlingLinkBuilderImplTest.java
+++ b/integration/aem/src/test/java/io/wcm/caravan/rhyme/aem/impl/linkbuilder/SlingLinkBuilderImplTest.java
@@ -206,6 +206,74 @@ public class SlingLinkBuilderImplTest {
     assertThat(link.getName()).isEqualTo(linkName);
   }
 
+  // --- template mode: partial expansion edge cases ---
+
+  @Test
+  void createLinkToCurrentResource_template_with_first_param_resolved() {
+
+    Link link = createLinkTemplateWithQueryParams(resource -> {
+      resource.foo = 1;
+    });
+
+    assertThat(link.getHref()).isEqualTo("/content.rhyme?foo=1{&bar,string}");
+  }
+
+  @Test
+  void createLinkToCurrentResource_template_with_last_param_resolved() {
+
+    Link link = createLinkTemplateWithQueryParams(resource -> {
+      resource.string = "test";
+    });
+
+    assertThat(link.getHref())
+        .contains("string=test")
+        .contains("{");
+  }
+
+  @Test
+  void createLinkToCurrentResource_template_with_all_params_resolved_matches_non_template() {
+
+    Link linkTemplate = createLinkTemplateWithQueryParams(resource -> {
+      resource.foo = 1;
+      resource.bar = 2;
+      resource.string = "test";
+    });
+
+    Link linkDirect = createLinkWithQueryParams(resource -> {
+      resource.foo = 1;
+      resource.bar = 2;
+      resource.string = "test";
+    });
+
+    assertThat(linkTemplate.getHref()).isEqualTo(linkDirect.getHref());
+  }
+
+  // --- template mode: special characters ---
+
+  @Test
+  void createLinkToCurrentResource_template_encodes_characters_during_partial_expansion() {
+
+    Link link = createLinkTemplateWithQueryParams(resource -> {
+      resource.string = "?/";
+    });
+
+    assertThat(link.getHref())
+        .contains("string=%3F%2F")
+        .contains("{");
+  }
+
+  // --- non-template mode: edge cases ---
+
+  @Test
+  void createLinkToCurrentResource_non_template_with_only_string_param() {
+
+    Link link = createLinkWithQueryParams(resource -> {
+      resource.string = "hello world";
+    });
+
+    assertThat(link.getHref()).contains("string=hello%20world");
+  }
+
   @Model(adaptables = SlingRhyme.class)
   public static class ResourceWithParameters extends AbstractLinkableResource {
 

--- a/integration/aem/src/test/java/io/wcm/caravan/rhyme/aem/impl/linkbuilder/SlingLinkBuilderImplTest.java
+++ b/integration/aem/src/test/java/io/wcm/caravan/rhyme/aem/impl/linkbuilder/SlingLinkBuilderImplTest.java
@@ -411,4 +411,28 @@ public class SlingLinkBuilderImplTest {
     assertThat(link.getHref()).isEqualTo("/content.rhyme");
   }
 
+  @Test
+  void createLinkToCurrentResource_with_all_empty_collection_params_should_not_fail() {
+
+    Link link = createLinkWithListParams(resource -> {
+      resource.ids = Collections.emptyList();
+      resource.tags = new String[0];
+      resource.filter = null;
+    });
+
+    assertThat(link.getHref()).isEqualTo("/content.rhyme");
+  }
+
+  @Test
+  void createLinkToCurrentResource_with_empty_array_and_resolved_string_should_not_fail() {
+
+    Link link = createLinkWithListParams(resource -> {
+      resource.tags = new String[0];
+      resource.filter = "active";
+    });
+
+    assertThat(link.getHref()).contains("filter=active");
+    assertThat(link.getHref()).doesNotContain("tags=");
+  }
+
 }

--- a/integration/aem/src/test/java/io/wcm/caravan/rhyme/aem/impl/linkbuilder/SlingLinkBuilderImplTest.java
+++ b/integration/aem/src/test/java/io/wcm/caravan/rhyme/aem/impl/linkbuilder/SlingLinkBuilderImplTest.java
@@ -2,6 +2,8 @@ package io.wcm.caravan.rhyme.aem.impl.linkbuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.function.Consumer;
 
 import org.apache.sling.models.annotations.Model;
@@ -302,6 +304,98 @@ public class SlingLinkBuilderImplTest {
     public void setString(String string) {
       this.string = string;
     }
+  }
+
+  // --- List-typed query parameters (Java 21 empty iterable issue) ---
+
+  @Model(adaptables = SlingRhyme.class)
+  public static class ResourceWithListParam extends AbstractLinkableResource {
+
+    @QueryParam
+    private List<Integer> ids;
+
+    @QueryParam
+    private String filter;
+
+    @Override
+    protected String getDefaultLinkTitle() {
+      return "resource with list";
+    }
+  }
+
+  private Link createLinkWithListParams(Consumer<ResourceWithListParam> paramProvider) {
+
+    SlingLinkBuilder linkBuilder = createLinkBuilder("/content");
+
+    ResourceWithListParam resource = new ResourceWithListParam();
+    paramProvider.accept(resource);
+
+    return linkBuilder.createLinkToCurrentResource(resource);
+  }
+
+  private Link createLinkTemplateWithListParams(Consumer<ResourceWithListParam> paramProvider) {
+
+    SlingLinkBuilder linkBuilder = createLinkBuilder("/content");
+
+    ResourceWithListParam resource = new ResourceWithListParam();
+    paramProvider.accept(resource);
+    resource.getLinkProperties().setTemplated(true);
+
+    return linkBuilder.createLinkToCurrentResource(resource);
+  }
+
+  @Test
+  void createLinkToCurrentResource_with_populated_list_param() {
+
+    Link link = createLinkWithListParams(resource -> {
+      resource.ids = List.of(1, 2, 3);
+    });
+
+    assertThat(link.getHref()).contains("ids=");
+  }
+
+  @Test
+  void createLinkToCurrentResource_with_empty_list_param_should_not_fail() {
+
+    Link link = createLinkWithListParams(resource -> {
+      resource.ids = Collections.emptyList();
+    });
+
+    assertThat(link.getHref()).isEqualTo("/content.rhyme");
+  }
+
+  @Test
+  void createLinkToCurrentResource_with_empty_list_and_resolved_string_should_not_fail() {
+
+    Link link = createLinkWithListParams(resource -> {
+      resource.ids = Collections.emptyList();
+      resource.filter = "active";
+    });
+
+    assertThat(link.getHref()).contains("filter=active");
+    assertThat(link.getHref()).doesNotContain("ids=");
+  }
+
+  @Test
+  void createLinkToCurrentResource_template_with_empty_list_should_not_fail() {
+
+    Link link = createLinkTemplateWithListParams(resource -> {
+      resource.ids = Collections.emptyList();
+    });
+
+    assertThat(link.getHref()).doesNotContain("ids=");
+  }
+
+  @Test
+  void createLinkToCurrentResource_template_with_empty_list_and_resolved_string_should_not_fail() {
+
+    Link link = createLinkTemplateWithListParams(resource -> {
+      resource.ids = Collections.emptyList();
+      resource.filter = "active";
+    });
+
+    assertThat(link.getHref()).contains("filter=active");
+    assertThat(link.getHref()).doesNotContain("ids=");
   }
 
 }

--- a/integration/aem/src/test/java/io/wcm/caravan/rhyme/aem/impl/linkbuilder/SlingLinkBuilderImplTest.java
+++ b/integration/aem/src/test/java/io/wcm/caravan/rhyme/aem/impl/linkbuilder/SlingLinkBuilderImplTest.java
@@ -411,14 +411,31 @@ public class SlingLinkBuilderImplTest {
     assertThat(link.getHref()).isEqualTo("/content.rhyme");
   }
 
+  @Model(adaptables = SlingRhyme.class)
+  public static class ResourceWithOnlyCollectionParams extends AbstractLinkableResource {
+
+    @QueryParam
+    private List<Integer> ids;
+
+    @QueryParam
+    private String[] tags;
+
+    @Override
+    protected String getDefaultLinkTitle() {
+      return "resource with collections only";
+    }
+  }
+
   @Test
   void createLinkToCurrentResource_with_all_empty_collection_params_should_not_fail() {
 
-    Link link = createLinkWithListParams(resource -> {
-      resource.ids = Collections.emptyList();
-      resource.tags = new String[0];
-      resource.filter = null;
-    });
+    SlingLinkBuilder linkBuilder = createLinkBuilder("/content");
+
+    ResourceWithOnlyCollectionParams resource = new ResourceWithOnlyCollectionParams();
+    resource.ids = Collections.emptyList();
+    resource.tags = new String[0];
+
+    Link link = linkBuilder.createLinkToCurrentResource(resource);
 
     assertThat(link.getHref()).isEqualTo("/content.rhyme");
   }
@@ -433,6 +450,16 @@ public class SlingLinkBuilderImplTest {
 
     assertThat(link.getHref()).contains("filter=active");
     assertThat(link.getHref()).doesNotContain("tags=");
+  }
+
+  @Test
+  void createLinkToCurrentResource_with_populated_array_param() {
+
+    Link link = createLinkWithListParams(resource -> {
+      resource.tags = new String[]{ "java", "maven" };
+    });
+
+    assertThat(link.getHref()).contains("tags=java,maven");
   }
 
 }

--- a/integration/osgi-jaxrs/pom.xml
+++ b/integration/osgi-jaxrs/pom.xml
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>io.wcm.caravan</groupId>
       <artifactId>io.wcm.caravan.rhyme.core</artifactId>
-      <version>1.2.0</version>
+      <version>1.2.1-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/integration/osgi-jaxrs/src/main/java/io/wcm/caravan/rhyme/jaxrs/impl/JaxRsControllerProxyLinkBuilder.java
+++ b/integration/osgi-jaxrs/src/main/java/io/wcm/caravan/rhyme/jaxrs/impl/JaxRsControllerProxyLinkBuilder.java
@@ -278,7 +278,10 @@ public class JaxRsControllerProxyLinkBuilder<T> implements InvocationHandler, Ja
         // This can be avoided by simply not adding this parameter to the template in the first place
         String key = StringUtils.substringBefore(varName, "*");
         Object value = parameterMap.get(key);
-        if (value instanceof Iterable && Iterables.isEmpty((Iterable)value)) {
+        if (value instanceof Iterable && Iterables.isEmpty((Iterable<?>)value)) {
+            continue;
+        }
+        if (value != null && value.getClass().isArray() && java.lang.reflect.Array.getLength(value) == 0) {
             continue;
         }
 

--- a/integration/osgi-jaxrs/src/main/java/io/wcm/caravan/rhyme/jaxrs/impl/JaxRsControllerProxyLinkBuilder.java
+++ b/integration/osgi-jaxrs/src/main/java/io/wcm/caravan/rhyme/jaxrs/impl/JaxRsControllerProxyLinkBuilder.java
@@ -56,7 +56,6 @@ import com.damnhandy.uri.template.UriTemplate;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 
 import io.wcm.caravan.hal.resource.Link;
@@ -278,10 +277,7 @@ public class JaxRsControllerProxyLinkBuilder<T> implements InvocationHandler, Ja
         // This can be avoided by simply not adding this parameter to the template in the first place
         String key = StringUtils.substringBefore(varName, "*");
         Object value = parameterMap.get(key);
-        if (value instanceof Iterable && Iterables.isEmpty((Iterable<?>)value)) {
-            continue;
-        }
-        if (value != null && value.getClass().isArray() && java.lang.reflect.Array.getLength(value) == 0) {
+        if (isEmptyCollection(value)) {
             continue;
         }
 
@@ -299,6 +295,16 @@ public class JaxRsControllerProxyLinkBuilder<T> implements InvocationHandler, Ja
       }
 
       return queries.toString();
+    }
+
+    private boolean isEmptyCollection(Object value) {
+      if (value instanceof Iterable) {
+        return !((Iterable<?>)value).iterator().hasNext();
+      }
+      if (value != null && value.getClass().isArray()) {
+        return java.lang.reflect.Array.getLength(value) == 0;
+      }
+      return false;
     }
 
     private String[] getQueryParameterVarNames(Predicate<TemplateParameter> valueAvailableCheck) {

--- a/integration/osgi-jaxrs/src/main/java/io/wcm/caravan/rhyme/jaxrs/impl/JaxRsControllerProxyLinkBuilder.java
+++ b/integration/osgi-jaxrs/src/main/java/io/wcm/caravan/rhyme/jaxrs/impl/JaxRsControllerProxyLinkBuilder.java
@@ -298,13 +298,13 @@ public class JaxRsControllerProxyLinkBuilder<T> implements InvocationHandler, Ja
     }
 
     private boolean isEmptyCollection(Object value) {
+      if (value == null) {
+        return false;
+      }
       if (value instanceof Iterable) {
         return !((Iterable<?>)value).iterator().hasNext();
       }
-      if (value != null && value.getClass().isArray()) {
-        return java.lang.reflect.Array.getLength(value) == 0;
-      }
-      return false;
+      return value.getClass().isArray() && java.lang.reflect.Array.getLength(value) == 0;
     }
 
     private String[] getQueryParameterVarNames(Predicate<TemplateParameter> valueAvailableCheck) {

--- a/integration/osgi-jaxrs/src/test/java/io/wcm/caravan/rhyme/jaxrs/impl/JaxRsControllerProxyLinkBuilderTest.java
+++ b/integration/osgi-jaxrs/src/test/java/io/wcm/caravan/rhyme/jaxrs/impl/JaxRsControllerProxyLinkBuilderTest.java
@@ -37,7 +37,6 @@ import javax.ws.rs.core.Response;
 import org.assertj.core.api.AbstractCharSequenceAssert;
 import org.junit.jupiter.api.Test;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -294,7 +293,7 @@ class JaxRsControllerProxyLinkBuilderTest {
   @Test
   void one_populated_list_query_param() {
 
-    assertLinkUrlFor(r -> r.withListQueryParam(ImmutableList.of("123", "456")))
+    assertLinkUrlFor(r -> r.withListQueryParam(List.of("123", "456")))
         .isEqualTo("/test?foo=123&foo=456");
   }
 
@@ -315,7 +314,7 @@ class JaxRsControllerProxyLinkBuilderTest {
   @Test
   void one_populated_list_query_param_before_string_param() {
 
-    assertLinkUrlFor(r -> r.withListAndStringQueryParam(ImmutableList.of("123", "456"), "789"))
+    assertLinkUrlFor(r -> r.withListAndStringQueryParam(List.of("123", "456"), "789"))
         .isEqualTo("/test?foo=123&foo=456&bar=789");
   }
 
@@ -384,14 +383,14 @@ class JaxRsControllerProxyLinkBuilderTest {
   @Test
   void one_populated_and_one_empty_list_query_param() {
 
-    assertLinkUrlFor(r -> r.withTwoListQueryParams(ImmutableList.of("a", "b"), Collections.emptyList()))
+    assertLinkUrlFor(r -> r.withTwoListQueryParams(List.of("a", "b"), Collections.emptyList()))
         .isEqualTo("/test?foo=a&foo=b");
   }
 
   @Test
   void one_empty_and_one_populated_list_query_param() {
 
-    assertLinkUrlFor(r -> r.withTwoListQueryParams(Collections.emptyList(), ImmutableList.of("x")))
+    assertLinkUrlFor(r -> r.withTwoListQueryParams(Collections.emptyList(), List.of("x")))
         .isEqualTo("/test?bar=x");
   }
 

--- a/integration/osgi-jaxrs/src/test/java/io/wcm/caravan/rhyme/jaxrs/impl/JaxRsControllerProxyLinkBuilderTest.java
+++ b/integration/osgi-jaxrs/src/test/java/io/wcm/caravan/rhyme/jaxrs/impl/JaxRsControllerProxyLinkBuilderTest.java
@@ -427,6 +427,21 @@ class JaxRsControllerProxyLinkBuilderTest {
         .isEqualTo("/test?bar=val");
   }
 
+  @Test
+  void populated_array_query_param() {
+
+    assertLinkUrlFor(r -> r.withArrayQueryParam(new String[]{ "a", "b" }))
+        .contains("foo=a,b");
+  }
+
+  @Test
+  void populated_array_query_param_with_resolved_string_param() {
+
+    assertLinkUrlFor(r -> r.withArrayAndStringQueryParam(new String[]{ "a", "b" }, "val"))
+        .contains("foo=a,b")
+        .contains("bar=val");
+  }
+
   // --- base URL prefix ---
 
   @Test

--- a/integration/osgi-jaxrs/src/test/java/io/wcm/caravan/rhyme/jaxrs/impl/JaxRsControllerProxyLinkBuilderTest.java
+++ b/integration/osgi-jaxrs/src/test/java/io/wcm/caravan/rhyme/jaxrs/impl/JaxRsControllerProxyLinkBuilderTest.java
@@ -101,6 +101,12 @@ class JaxRsControllerProxyLinkBuilderTest {
     }
 
     @GET
+    @Path("/test")
+    public Response withTwoListQueryParams(@QueryParam("foo") List<String> foo, @QueryParam("bar") List<String> bar) {
+      return Response.ok(foo + "" + bar).build();
+    }
+
+    @GET
     @Path("/test/{foo}")
     public Response withStringPathParam(@PathParam("foo") String foo) {
       return Response.ok(foo).build();
@@ -350,6 +356,113 @@ class JaxRsControllerProxyLinkBuilderTest {
 
     assertLinkUrlFor(r -> r.withBeanParam(params))
         .isEqualTo("/test/123?bar=456&withDefault=replacement");
+  }
+
+  // --- Java 21 workaround: empty iterable query params are skipped from the template ---
+
+  @Test
+  void empty_list_query_param_with_unresolved_string_param() {
+
+    assertLinkUrlFor(r -> r.withListAndStringQueryParam(Collections.emptyList(), null))
+        .isEqualTo("/test{?bar}");
+  }
+
+  @Test
+  void empty_list_query_param_with_unresolved_string_param_and_null_list() {
+
+    assertLinkUrlFor(r -> r.withTwoListQueryParams(Collections.emptyList(), null))
+        .isEqualTo("/test{?bar*}");
+  }
+
+  @Test
+  void two_empty_list_query_params() {
+
+    assertLinkUrlFor(r -> r.withTwoListQueryParams(Collections.emptyList(), Collections.emptyList()))
+        .isEqualTo("/test");
+  }
+
+  @Test
+  void one_populated_and_one_empty_list_query_param() {
+
+    assertLinkUrlFor(r -> r.withTwoListQueryParams(ImmutableList.of("a", "b"), Collections.emptyList()))
+        .isEqualTo("/test?foo=a&foo=b");
+  }
+
+  @Test
+  void one_empty_and_one_populated_list_query_param() {
+
+    assertLinkUrlFor(r -> r.withTwoListQueryParams(Collections.emptyList(), ImmutableList.of("x")))
+        .isEqualTo("/test?bar=x");
+  }
+
+  // --- base URL prefix ---
+
+  @Test
+  void base_url_is_prepended_to_path() {
+
+    JaxRsLinkBuilder<JaxRsComponent> linkBuilder = JaxRsLinkBuilder.create("/api", JaxRsComponent.class);
+
+    Link link = linkBuilder.buildLinkTo(r -> r.foo());
+
+    assertThat(link.getHref()).isEqualTo("/api/foo");
+  }
+
+  @Test
+  void base_url_is_prepended_with_query_params() {
+
+    JaxRsLinkBuilder<JaxRsComponent> linkBuilder = JaxRsLinkBuilder.create("/api", JaxRsComponent.class);
+
+    Link link = linkBuilder.buildLinkTo(r -> r.withStringQueryParam("val"));
+
+    assertThat(link.getHref()).isEqualTo("/api/test?foo=val");
+  }
+
+  @Test
+  void base_url_is_prepended_with_path_and_query_template() {
+
+    JaxRsLinkBuilder<JaxRsComponent> linkBuilder = JaxRsLinkBuilder.create("/api", JaxRsComponent.class);
+
+    Link link = linkBuilder.buildLinkTo(r -> r.withTwoStringQueryParams(null, null));
+
+    assertThat(link.getHref()).isEqualTo("/api/test{?foo,bar}");
+  }
+
+  // --- special characters in query param values ---
+
+  @Test
+  void special_characters_in_query_param_are_encoded() {
+
+    assertLinkUrlFor(r -> r.withStringQueryParam("hello world"))
+        .contains("foo=hello%20world");
+  }
+
+  @Test
+  void special_characters_in_path_param_are_encoded() {
+
+    assertLinkUrlFor(r -> r.withStringPathParam("a/b"))
+        .isEqualTo("/test/a%2Fb");
+  }
+
+  // --- mixed path and query with partial expansion ---
+
+  @Test
+  void path_param_resolved_with_unresolved_query_param() {
+
+    ParamBean params = new ParamBean();
+    params.foo = "123";
+
+    assertLinkUrlFor(r -> r.withBeanParam(params))
+        .isEqualTo("/test/123{?bar,withDefault}");
+  }
+
+  @Test
+  void path_param_unresolved_with_resolved_query_param() {
+
+    ParamBean params = new ParamBean();
+    params.bar = "456";
+
+    assertLinkUrlFor(r -> r.withBeanParam(params))
+        .isEqualTo("/test/{foo}?bar=456{&withDefault}");
   }
 
   public static final class FinalJaxRsComponent {

--- a/integration/osgi-jaxrs/src/test/java/io/wcm/caravan/rhyme/jaxrs/impl/JaxRsControllerProxyLinkBuilderTest.java
+++ b/integration/osgi-jaxrs/src/test/java/io/wcm/caravan/rhyme/jaxrs/impl/JaxRsControllerProxyLinkBuilderTest.java
@@ -106,6 +106,18 @@ class JaxRsControllerProxyLinkBuilderTest {
     }
 
     @GET
+    @Path("/test")
+    public Response withArrayQueryParam(@QueryParam("foo") String[] foo) {
+      return Response.ok(foo).build();
+    }
+
+    @GET
+    @Path("/test")
+    public Response withArrayAndStringQueryParam(@QueryParam("foo") String[] foo, @QueryParam("bar") String bar) {
+      return Response.ok(foo + bar).build();
+    }
+
+    @GET
     @Path("/test/{foo}")
     public Response withStringPathParam(@PathParam("foo") String foo) {
       return Response.ok(foo).build();
@@ -392,6 +404,27 @@ class JaxRsControllerProxyLinkBuilderTest {
 
     assertLinkUrlFor(r -> r.withTwoListQueryParams(Collections.emptyList(), List.of("x")))
         .isEqualTo("/test?bar=x");
+  }
+
+  @Test
+  void empty_array_query_param_only() {
+
+    assertLinkUrlFor(r -> r.withArrayQueryParam(new String[0]))
+        .isEqualTo("/test");
+  }
+
+  @Test
+  void empty_array_query_param_with_unresolved_string_param() {
+
+    assertLinkUrlFor(r -> r.withArrayAndStringQueryParam(new String[0], null))
+        .isEqualTo("/test{?bar}");
+  }
+
+  @Test
+  void empty_array_query_param_with_resolved_string_param() {
+
+    assertLinkUrlFor(r -> r.withArrayAndStringQueryParam(new String[0], "val"))
+        .isEqualTo("/test?bar=val");
   }
 
   // --- base URL prefix ---

--- a/integration/spring/pom.xml
+++ b/integration/spring/pom.xml
@@ -110,7 +110,7 @@
     <dependency>
       <groupId>io.wcm.caravan</groupId>
       <artifactId>io.wcm.caravan.rhyme.core</artifactId>
-      <version>1.2.0</version>
+      <version>1.2.1-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
   

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -73,7 +73,7 @@
     <dependency>
       <groupId>io.wcm.caravan</groupId>
       <artifactId>io.wcm.caravan.rhyme.core</artifactId>
-      <version>1.2.0</version>
+      <version>1.2.1-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <!-- AssertJ for fluent assertions -->


### PR DESCRIPTION
## Summary

- Apply a workaround for a Java 21+ behavioral change in the `handy-uri-templates` library that throws `VarExploderException` when expanding URI templates with empty `Iterable` or array values
- Apply the workaround consistently across all four affected modules (core, AEM, OSGi-JAX-RS, AWS Lambda)
- Bump the `rhyme.core` dependency from 1.2.0 to 1.2.1-SNAPSHOT in all consuming modules so the core-level fix (in `RelatedResourceHandler.expandLinkTemplates`) is effective everywhere
- Add comprehensive test coverage for URI template expansion across all modules

### Java 21 workaround

Each module filters out empty collections before passing them to the `UriTemplate` API, using a consistent `isEmptyCollection()` helper that handles both `Iterable` and array types:

- **core** `RelatedResourceHandler` — client-side link template expansion
- **integration/aem** `SlingLinkBuilderImpl` — server-side link building
- **integration/osgi-jaxrs** `JaxRsControllerProxyLinkBuilder` — server-side link building
- **examples/aws-lambda** `LambdaLinkBuilderImpl` — server-side link building

### Core dependency bump (1.2.0 → 1.2.1-SNAPSHOT)

Updated in all consuming modules so the core-level client proxy fix is effective:

- `integration/osgi-jaxrs`
- `integration/aem`
- `integration/spring`
- `testing`
- `examples/aws-movie-search`
- `examples/osgi-jaxrs-example-launchpad`
- `tooling/coverage`

The only module left on 1.2.0 is `tooling/docs-maven-plugin`, which does not use client proxy or URI template expansion.

### Test coverage (63 new tests)

- **core** — `TemplateVariableTest` (11), `TemplatedResourceLoadingTest` (5), `UriTemplateEmptyIterableTest` (8)
- **integration/aem** — `SlingLinkBuilderImplTest` (13), `TemplateProxyPostAdaptationStageTest` (3)
- **integration/osgi-jaxrs** — `JaxRsControllerProxyLinkBuilderTest` (12)
- **examples/aws-lambda** — `LambdaLinkBuilderImplTest` (11)

## Test plan
- [ ] Full CI build passes (`mvn clean install -Pcontinuous-integration`)
- [ ] All new tests pass on Java 17 and Java 21+
- [ ] No production behavior changes for non-empty collections — workaround only affects the empty case

🤖 Generated with [Claude Code](https://claude.com/claude-code)